### PR TITLE
docs(book): scaffold mdBook and CI for GitHub Pages

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -1,0 +1,36 @@
+name: Deploy mdBook
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ "v*" ]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install mdBook
+        run: |
+          curl -sSL https://github.com/rust-lang/mdBook/releases/latest/download/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz -C /usr/local/bin mdbook
+          mdbook --version
+
+      - name: Build book
+        run: mdbook build
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: book/book
+          force_orphan: true
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/book.toml
+++ b/book.toml
@@ -1,0 +1,20 @@
+[book]
+title = "bevy_repl Book"
+authors = ["Philip Linden"]
+language = "en"
+multilingual = false
+src = "book/src"
+
+[output.html]
+# Link back to the repository
+git-repository-url = "https://github.com/philiplinden/bevy_repl"
+# Needed so relative links work when hosted at https://<user>.github.io/bevy_repl/
+site-url = "/bevy_repl/"
+
+[output.html.fold]
+# Enable code block folding UI
+enable = true
+
+[build]
+# Keep default build dir (book/book) because CI deploys that to gh-pages
+create-missing = true

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,0 +1,20 @@
+# Summary
+
+- [Introduction](intro.md)
+- Getting Started
+  - [Quickstart](getting_started.md)
+  - [Examples](examples.md)
+- Guides
+  - [Command Parsing](command_parsing.md)
+  - [Scheduling](scheduling.md)
+  - [Prompt Styling](prompt_styling.md)
+  - [Terminal Screens](terminal_screens.md)
+  - [Logging](logging.md)
+- Reference
+  - [Built-ins](builtins.md)
+  - [Configuration](configuration.md)
+  - [Known Issues & Limitations](known_issues.md)
+- Project
+  - [Architecture](architecture.md)
+  - [Changelog](changelog.md)
+  - [License](license.md)

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -1,0 +1,10 @@
+# Architecture
+
+High-level overview of systems, resources, and plugins involved in the REPL.
+
+- Core modules live under `src/`.
+- Commands: `src/command/`
+- Prompt & renderer: `src/prompt/`
+- Built-ins: `src/built_ins/`
+
+See the Logging chapter for the display strategies and how they integrate.

--- a/book/src/builtins.md
+++ b/book/src/builtins.md
@@ -1,0 +1,8 @@
+# Built-ins
+
+Built-in commands provided by the REPL.
+
+- `help` — list commands and usage
+- `clear` — clear the screen
+
+See `src/built_ins/` for implementation details.

--- a/book/src/changelog.md
+++ b/book/src/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+The changelog from the repository is embedded below.
+
+{{#include ../../CHANGELOG.md}}

--- a/book/src/command_parsing.md
+++ b/book/src/command_parsing.md
@@ -1,0 +1,6 @@
+# Command Parsing
+
+Overview of how commands are defined, parsed, and executed.
+
+- See `src/command/` for implementation details.
+- Examples in the Examples chapter.

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -1,0 +1,7 @@
+# Configuration
+
+Feature flags, plugins, and runtime options.
+
+- See crate features in `Cargo.toml`.
+- Configure plugins and renderers in your app's setup code.
+- Check examples for common configurations.

--- a/book/src/examples.md
+++ b/book/src/examples.md
@@ -1,0 +1,11 @@
+# Examples
+
+See the repository examples directory for runnable samples:
+
+- https://github.com/philiplinden/bevy_repl/tree/main/examples
+
+Run an example locally:
+
+```bash
+cargo run --example builder
+```

--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -1,0 +1,6 @@
+# Getting Started
+
+This guide shows how to add bevy_repl to a Bevy app and run it.
+
+- See the Examples chapter for runnable samples.
+- API reference: https://docs.rs/bevy_repl

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -1,0 +1,12 @@
+# bevy_repl
+
+A REPL for Bevy apps, with a terminal UI powered by ratatui.
+
+- API reference: https://docs.rs/bevy_repl
+- Source: https://github.com/philiplinden/bevy_repl
+
+This book contains:
+- Quickstart for adding the REPL to your Bevy app
+- Guides: parsing, scheduling, prompt styling, terminal screens, logging
+- Reference: built-ins, configuration, known issues
+- Project: architecture, changelog, license

--- a/book/src/known_issues.md
+++ b/book/src/known_issues.md
@@ -1,0 +1,10 @@
+# Known Issues & Limitations
+
+Known rough edges and limitations. See README for the latest details.
+
+- Built-in `help` and `clear` may be incomplete.
+- Runtime toggle not supported.
+- Key events not forwarded while REPL is enabled.
+- Renderer prompt buffer may not scroll with terminal output.
+- Shift+ combinations not entered into the buffer.
+- Direct terminal manipulation can be fragile.

--- a/book/src/license.md
+++ b/book/src/license.md
@@ -1,0 +1,6 @@
+# License
+
+This project is dual-licensed under Apache-2.0 or MIT, at your option.
+
+- Apache-2.0: {{#include ../../LICENSE-APACHE }}
+- MIT: {{#include ../../LICENSE-MIT }}

--- a/book/src/logging.md
+++ b/book/src/logging.md
@@ -1,0 +1,21 @@
+# Logging
+
+This crate supports two complementary logging display strategies. Choose one per app to avoid duplicates.
+
+- Stdout strategy (terminal scrollback)
+  - Capture tracing/log events and print to the terminal output area.
+  - Works best when not using an alternate screen (plain stdout renderer).
+  - Components referenced: `CaptureSubscriber`, `print_log_events_system`.
+
+- In-frame strategy (TUI frame)
+  - Captures events into an in-memory buffer and renders logs inside the ratatui frame above the prompt.
+  - Works best with an alternate-screen TUI.
+  - Components referenced: `LogBufferPlugin`, `LogBuffer`.
+
+Guideline:
+- Do not enable both simultaneously.
+- Select based on the active renderer (e.g., via `PromptRenderer::strategy()`), and wire only one path into your app.
+
+Notes:
+- API surface and specific types may evolve; consult the examples and source code for current wiring.
+- Consider adding structured spans around REPL commands to improve trace readability.

--- a/book/src/prompt_styling.md
+++ b/book/src/prompt_styling.md
@@ -1,0 +1,6 @@
+# Prompt Styling
+
+Notes on customizing the prompt appearance and behavior.
+
+- Colors, borders, and layout are handled by the renderer.
+- See `src/prompt/` for implementation details.

--- a/book/src/scheduling.md
+++ b/book/src/scheduling.md
@@ -1,0 +1,6 @@
+# Scheduling
+
+How the REPL integrates with Bevy schedules and systems.
+
+- See `src/command/parser.rs` and `src/command/mod.rs`.
+- Example schedules are demonstrated in the examples.

--- a/book/src/terminal_screens.md
+++ b/book/src/terminal_screens.md
@@ -1,0 +1,6 @@
+# Terminal Screens
+
+Details about the renderer modes and screen behavior.
+
+- The TUI runs in an alternate screen (ratatui) to keep the prompt visible.
+- See `src/prompt/renderer/` for implementation.


### PR DESCRIPTION
The README was getting bloated. Let's move most of the stuff to a dedicated book.