### PR TITLE
Upgrade to Bevy 0.19

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -29,12 +29,17 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: 'latest'
+          # Pinned to 0.4.x: mdbook-alerts depends on the `mdbook` crate directly
+          # and hasn't been updated for the 0.5.x RenderContext format yet.
+          mdbook-version: '0.4.52'
 
       - name: Install mdBook Table of Contents plugin
         uses: baptiste0928/cargo-install@v3
         with:
           crate: mdbook-toc
+          # 0.15.x switched to the mdbook-preprocessor crate, which targets the
+          # mdbook 0.5.x format; pin to the last 0.4.x-compatible release.
+          version: '0.14.2'
 
       - name: Install mdBook alerts plugin
         uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run unit tests
+        run: cargo test --lib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ See [GitHub Releases](https://github.com/philiplinden/bevy_repl/releases) and th
 ### ⚙️ Repository
 
 - *(docs)* Build mdBook on PR, deploy only on tags using mdBook action ([`2e090cd`](https://github.com/philiplinden/bevy_repl/commit/2e090cd8acd32380afbd60a2e0dc18bce9fd5390))
+- Fix workflow deployments ([`d5726dc`](https://github.com/philiplinden/bevy_repl/commit/d5726dc6a0856b2bdba04d09affe4df9a4b84a65))
 - Use the real github action for pages ([`06030f1`](https://github.com/philiplinden/bevy_repl/commit/06030f1ad0c06b38946cafc7be621f7e8b1fc067))
 - Deploy the book on every push to main ([`c4589a2`](https://github.com/philiplinden/bevy_repl/commit/c4589a25f531830ba41b1ab5334dcf6383fe07ac))
 - Make the book on every push to main ([`563574c`](https://github.com/philiplinden/bevy_repl/commit/563574cd55ca3028cf9ddb66fd6b1e5f3eb920ed))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ keywords = ["bevy", "repl", "console", "debugging"]
 categories = ["game-development", "development-tools"]
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = ["bevy_log", "trace"]}
-bevy_ratatui = { version = "0.11", features = ["crossterm"] }
-ratatui = "0.30.0"
-clap = { version = "4.5.46" }
+bevy = { version = "0.19", default-features = false, features = ["bevy_log", "trace"]}
+bevy_ratatui = { git = "https://github.com/apekros/bevy_ratatui", rev = "631c06f160ca04ae9960c58bb399cb23513a60eb", features = ["crossterm"] }
+ratatui = "0.30.2"
+clap = { version = "4.6.1" }
 shell-words = "1.1"
 bevy_repl_derive = { version = "0.1.0", path = "./bevy_repl_derive", optional = true }
 ctrlc = "3"
-anyhow = "1.0.99"
+anyhow = "1.0.103"
 color-eyre = "0.6.5"
 
 # Error handling and logging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,14 @@ keywords = ["bevy", "repl", "console", "debugging"]
 categories = ["game-development", "development-tools"]
 
 [dependencies]
-bevy = { version = "0.16.1", default-features = false, features = ["bevy_log", "trace"]}
-bevy_ratatui = { version = "0.9.2", features = ["crossterm"] }
+# MIGRATION: Updating to Bevy 0.17 - this is the core dependency change
+# TODO: Verify all features still exist in 0.17
+bevy = { version = "0.17", default-features = false, features = ["bevy_log", "trace"]}
+# MIGRATION TODO: bevy_ratatui 0.9.2 targets Bevy 0.16
+# Need to find a 0.17-compatible version or use a git branch
+# For now, leaving as-is but this WILL break compilation
+# Check: https://github.com/cxreiff/bevy_ratatui for 0.17 support
+bevy_ratatui = { version = "0.9.2", features = ["crossterm"] }  # FIXME: Needs 0.17-compatible version
 ratatui = "0.29.0"
 clap = { version = "4.5.46" }
 shell-words = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "bevy_repl_derive"]
 
 [package]
 name = "bevy_repl"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 description = "Add a REPL to headless Bevy applications"
 license = "MIT"
@@ -12,27 +12,21 @@ keywords = ["bevy", "repl", "console", "debugging"]
 categories = ["game-development", "development-tools"]
 
 [dependencies]
-# MIGRATION: Updating to Bevy 0.17 - this is the core dependency change
-# TODO: Verify all features still exist in 0.17
-bevy = { version = "0.17", default-features = false, features = ["bevy_log", "trace"]}
-# MIGRATION TODO: bevy_ratatui 0.9.2 targets Bevy 0.16
-# Need to find a 0.17-compatible version or use a git branch
-# For now, leaving as-is but this WILL break compilation
-# Check: https://github.com/cxreiff/bevy_ratatui for 0.17 support
-bevy_ratatui = { version = "0.9.2", features = ["crossterm"] }  # FIXME: Needs 0.17-compatible version
-ratatui = "0.29.0"
+bevy = { version = "0.18", default-features = false, features = ["bevy_log", "trace"]}
+bevy_ratatui = { version = "0.11", features = ["crossterm"] }
+ratatui = "0.30.0"
 clap = { version = "4.5.46" }
 shell-words = "1.1"
 bevy_repl_derive = { version = "0.1.0", path = "./bevy_repl_derive", optional = true }
 ctrlc = "3"
+anyhow = "1.0.99"
+color-eyre = "0.6.5"
 
 # Error handling and logging
-anyhow = "1.0.99"
 tracing = { version = "0.1", features = [
     "max_level_trace",
     "release_max_level_warn",
 ] }
-color-eyre = "0.6.5"
 
 [features]
 default = [

--- a/bevy_repl_derive/Cargo.toml
+++ b/bevy_repl_derive/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
-clap = { version = "4.5.45", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive"] }

--- a/book.toml
+++ b/book.toml
@@ -2,7 +2,6 @@
 title = "Bevy REPL Book"
 authors = ["Philip Linden"]
 language = "en"
-multilingual = false
 src = "doc/src"
 
 [build]

--- a/doc/notes/2025-10-06-bevy-0.17-migration-notes.md
+++ b/doc/notes/2025-10-06-bevy-0.17-migration-notes.md
@@ -91,3 +91,307 @@ Notes:
   - https://youtu.be/BtwNc_sx1pE
   - https://github.com/rust-adventure/bevy-examples/tree/main/concepts/hooks_and_observers/src/bin
 nd Hooks Cheat Sheet
+
+
+Great question! Let me assess the **blast radius** of this change:
+
+## 🔍 What BREAKS (Needs Rewrite)
+
+### High Impact (~4-6 hours)
+
+**`src/prompt/input.rs`** - Complete rewrite (~2-3 hours)
+```diff
+- Uses bevy_ratatui's event bridge
++ Direct crossterm event polling
+- Relies on bevy_ratatui's RatatuiContext
++ Custom TerminalState resource
+```
+**Changes needed:**
+- Remove all bevy_ratatui imports
+- Replace event reading with `crossterm::event::poll()` + `read()`
+- Handle cursor positioning yourself
+- Add history/completion logic
+
+**Terminal setup/teardown** - New code (~1 hour)
+```rust
+// NEW: src/terminal.rs (create this file)
+- No equivalent in current code (bevy_ratatui did this)
++ setup_terminal() - enable_raw_mode, configure
++ cleanup_terminal() - disable_raw_mode, restore
++ TerminalState resource
++ PromptRenderer resource
+```
+
+**`src/prompt/keymap.rs`** - Moderate changes (~1 hour)
+```diff
+- If this maps bevy_ratatui events
++ Map crossterm KeyEvent directly
+```
+Depends on current implementation - might be minor.
+
+**Output rendering** - New system (~1-2 hours)
+```rust
+// NEW: Sticky prompt rendering system
+- Currently: probably prints to stdout directly?
++ PromptRenderer that manages cursor positioning
++ Coordinate output above prompt line
+```
+
+### Medium Impact (~2-3 hours)
+
+**`src/log_ecs.rs`** - Routing changes (~1 hour)
+```diff
+- Direct println!() or ratatui widgets?
++ Route through PromptRenderer.print_output()
+```
+Logic stays same, just different output target.
+
+**Plugin setup** - Resource initialization (~30 min)
+```rust
+// src/repl.rs or src/lib.rs
+impl Plugin for ReplPlugin {
+    fn build(&self, app: &mut App) {
+-       // bevy_ratatui plugin setup
++       // Custom terminal resources
++       .init_resource::<TerminalState>()
++       .init_resource::<CommandHistory>()
++       .init_resource::<CompletionEngine>()
++       .init_resource::<PromptRenderer>()
++       .add_systems(Startup, setup_terminal)
++       .add_systems(PostUpdate, cleanup_terminal.run_if(/* on exit */))
+    }
+}
+```
+
+**Cargo.toml** - Dependencies (~5 min)
+```diff
+[dependencies]
+- bevy_ratatui = "0.9"
+- ratatui = "0.28" # (if used directly)
++ crossterm = "0.28"
+```
+
+## ✅ What DOESN'T Break (Untouched)
+
+### Zero Impact
+
+**Command system** - 100% intact ✅
+- `src/command/parser.rs` - Still reads `ReplSubmitEvent`
+- `src/command/register.rs` - Still registers commands
+- `src/built_ins/*.rs` - All built-in commands unchanged
+- Command execution flow - Completely unaffected
+
+**Event flow** - Mostly intact ✅
+```rust
+// These Message types and flow remain identical
+ReplBufferEvent  // Still triggered on keypress
+ReplSubmitEvent  // Still triggered on Enter
+ReplLifecycleEvent // Unchanged
+
+// Systems still read/write these
+MessageReader<ReplSubmitEvent>  // Parser still reads this
+MessageWriter<ReplBufferEvent>  // Input still writes this
+```
+
+**Game integration** - 100% intact ✅
+- Observer-based commands unchanged
+- Game state access unchanged
+- Command registration API unchanged
+- Examples' command definitions unchanged
+
+**Business logic** - 100% intact ✅
+- Command parsing logic
+- Command validation
+- Error handling
+- Output formatting (just routes differently)
+
+## 📊 Destruction Matrix
+
+| Component | Impact | Effort | Can Reuse? |
+|-----------|--------|--------|------------|
+| Command system | **None** ✅ | 0 hours | 100% |
+| Event flow | **Low** | 0.5 hours | 90% (just routing) |
+| Input handling | **High** 🔴 | 2-3 hours | 30% (logic, not impl) |
+| Terminal setup | **High** 🔴 | 1 hour | 0% (new) |
+| Output/rendering | **High** 🔴 | 2 hours | 20% (concept) |
+| History (new) | **N/A** | 1 hour | N/A (adding) |
+| Completion (new) | **N/A** | 2 hours | N/A (adding) |
+| Examples | **None** ✅ | 0 hours | 100% |
+| Built-in commands | **None** ✅ | 0 hours | 100% |
+
+**Total destructiveness: ~30% of codebase**
+
+## 🎯 What You Can Salvage
+
+### Keep 100% As-Is
+```
+src/command/
+  ├── parser.rs        ✅ Keep (maybe update 1 import)
+  ├── register.rs      ✅ Keep (untouched)
+  └── ...
+  
+src/built_ins/
+  ├── quit.rs          ✅ Keep (except AppExit change)
+  ├── help.rs          ✅ Keep
+  └── ...
+  
+examples/
+  ├── basic.rs         ✅ Keep (command defs unchanged)
+  ├── game_integration.rs ✅ Keep
+  └── ...
+```
+
+### Refactor (Keep Logic, Change Impl)
+```
+src/prompt/
+  ├── input.rs         🔄 Rewrite input polling, keep event logic
+  ├── keymap.rs        🔄 Minimal changes (if any)
+  └── ...
+  
+src/log_ecs.rs         🔄 Keep logic, change output routing
+src/repl.rs            🔄 Keep state, change initialization
+```
+
+### Create New
+```
+src/
+  ├── terminal.rs      🆕 Terminal setup/cleanup
+  ├── prompt/
+  │   ├── history.rs   🆕 History navigation
+  │   ├── completion.rs 🆕 Tab completion
+  │   └── renderer.rs  🆕 Sticky prompt rendering
+```
+
+## 📈 Migration Strategy (Minimize Destruction)
+
+### Phase 1: Parallel Implementation (Safe)
+```rust
+// Keep bevy_ratatui working while you build new system
+app
+    .add_plugins(RatatuiPlugins::default()) // OLD
+    .init_resource::<NewTerminalState>()    // NEW (parallel)
+```
+
+Work on new system in separate files, don't touch existing yet.
+
+### Phase 2: Feature Flag (Controlled)
+```toml
+[features]
+default = ["ratatui-backend"]
+ratatui-backend = ["bevy_ratatui"]
+crossterm-backend = []
+```
+
+Users can test new backend without breaking existing.
+
+### Phase 3: Switchover (Quick)
+Once new backend works:
+1. Remove bevy_ratatui dependency (1 min)
+2. Update `src/prompt/input.rs` to use new polling (30 min)
+3. Update `src/log_ecs.rs` to use PromptRenderer (15 min)
+4. Update plugin initialization (15 min)
+5. Delete old ratatui-specific code (5 min)
+
+**Switchover time: ~1 hour** (after new system built)
+
+## 🛡️ Risk Mitigation
+
+### Low-Risk Approach
+
+**Step 1: Extract interfaces** (1 hour)
+```rust
+// src/prompt/mod.rs
+pub trait InputProvider {
+    fn poll_input(&mut self) -> Vec<InputEvent>;
+}
+
+pub trait OutputProvider {
+    fn print_line(&mut self, line: String);
+}
+
+// Implement for both old and new
+impl InputProvider for RatatuiInput { /* ... */ }
+impl InputProvider for CrosstermInput { /* ... */ }
+```
+
+Now you can swap implementations without touching consumers.
+
+**Step 2: Build alongside** (6-8 hours)
+Create complete crossterm implementation in isolation.
+
+**Step 3: Atomic swap** (1 hour)
+Change 5 lines in plugin setup, everything else unchanged.
+
+### Rollback Plan
+
+If it doesn't work:
+```bash
+git checkout src/prompt/input.rs   # Restore input
+git checkout src/terminal.rs       # Remove new code
+git checkout Cargo.toml            # Restore bevy_ratatui
+cargo build                        # Back to working
+```
+
+**Rollback time: 2 minutes**
+
+## 💰 Cost-Benefit Analysis
+
+### Costs
+- **Time**: 8-12 hours total effort
+- **Risk**: Medium (touching core input/output)
+- **Disruption**: ~30% of codebase
+- **Testing**: Need thorough validation
+
+### Benefits
+- **Unblocked**: No bevy_ratatui dependency ✅
+- **Features**: History + completion ✅
+- **Performance**: Non-blocking, Bevy-native ✅
+- **Control**: Sticky prompt, custom UX ✅
+- **Future-proof**: Never blocked on bevy_ratatui again ✅
+
+## 🎯 Verdict: **Moderately Destructive, High Reward**
+
+### Destructiveness Score: **5/10**
+- Not trivial (can't do in 1 hour)
+- Not catastrophic (70% of code untouched)
+- Concentrated in 3-4 files
+- Business logic preserved
+
+### Recommendation: **DO IT**
+
+**Why:**
+1. You're **already rewriting** for Bevy 0.17 (Event→Message, Trigger→On)
+2. Migration work is **similar effort** to bevy_ratatui patches
+3. Gets you **permanent independence** (no more version coupling)
+4. Adds **valuable features** (history, completion)
+5. Command system stays intact (your core value prop)
+
+### Timeline
+```
+Week 1 (Current): Plan + Bevy 0.17 Message/Event changes (4 hours)
+Week 2: Build new terminal system in parallel (8 hours)
+Week 3: Swap implementation, test, iterate (4 hours)
+Total: ~16 hours spread over 2-3 weeks
+```
+
+## 🚦 Go/No-Go Checklist
+
+**Go ahead if:**
+- ✅ You have 2-3 weeks timeline
+- ✅ You're okay testing thoroughly
+- ✅ You want history/completion anyway
+- ✅ You want to avoid bevy_ratatui coupling forever
+
+**Don't do it if:**
+- ❌ Need to ship in <1 week
+- ❌ Can't afford any bugs
+- ❌ bevy_ratatui 0.17 already released (wait, is it?)
+- ❌ Happy with blocking readline UI
+
+---
+
+**My take**: It's **moderately destructive but highly worthwhile**. The core
+REPL functionality (commands, parsing, observers) is untouched. You're mainly
+rewriting the input/output layer, which you'd need to touch for Bevy 0.17
+anyway. The permanent independence from bevy_ratatui version coupling is worth
+it.

--- a/doc/notes/2025-10-06-bevy-0.17-migration-notes.md
+++ b/doc/notes/2025-10-06-bevy-0.17-migration-notes.md
@@ -1,0 +1,93 @@
+# Bevy 0.16 → 0.17 Migration Impact for `bevy_repl`
+
+This note summarizes upstream changes, concrete repo impacts, a step-by-step plan, and an effort estimate to support Bevy 0.17.
+
+## Summary of impactful upstream changes
+- **Buffered events are now Messages**: `EventReader`/`EventWriter`/`Events<T>` renamed to `MessageReader`/`MessageWriter`/`Messages<T>`. Types meant for buffered dispatch should derive `Message` (not `Event`).
+  - Guide: https://bevy.org/learn/migration-guides/0-16-to-0-17/ (see “Event trait split / Rename”).
+- **Observers API polish**: Observer system param `Trigger<T>` is now `On<T>`. Add/remove/enter/exit and general observers continue to work; only the parameter name/type changed.
+  - Release notes: https://bevy.org/news/bevy-0-17/ (see “The Event trait”, “Trigger → On”).
+- **Keyboard**: `ButtonInput<KeyCode>` remains. The new logical `Key` type exists, but current uses of `KeyCode` (physical) continue to work. Our REPL input path uses Crossterm key events via `bevy_ratatui`; unaffected.
+  - Docs: https://bevy-cheatbook.github.io/input/keyboard.html
+
+ ## What changes in this repo
+ Most changes are renames for our buffered “events” to “messages”. Observer-based command events remain `Event`. In 0.17, non-generic `Event` types are auto-registered (with default features), so `add_event::<T>()` is usually not needed. Keep manual registration only for generic events or if `reflect_auto_register` is disabled.
+
+### 1) Buffered messages (derive + API)
+Change the following types from `#[derive(Event)]` to `#[derive(Message)]` and update all readers/writers/registrations:
+- `src/repl.rs`
+  - Types: `ReplBufferEvent`, `ReplSubmitEvent`, `ReplLifecycleEvent` → derive `Message`.
+  - App registration: `app.add_event::<…>()` → `app.add_message::<…>()` for these buffered types.
+  - System params:
+    - `EventReader<ReplBufferEvent>` → `MessageReader<ReplBufferEvent>`
+    - `EventWriter<ReplSubmitEvent>` → `MessageWriter<ReplSubmitEvent>`
+- `src/log_ecs.rs`
+  - Type: `LogEvent` → derive `Message`.
+  - Registration: `add_event::<LogEvent>()` → `add_message::<LogEvent>()`.
+  - Readers/writers: `EventReader/Writer<LogEvent>` → `MessageReader/Writer<LogEvent>`.
+- `src/prompt/input.rs`
+  - `EventReader<ReplBufferEvent>` → `MessageReader<ReplBufferEvent>` in `update_repl_buffer()`.
+  - `EventWriter<ReplSubmitEvent>` → `MessageWriter<ReplSubmitEvent>` in `update_repl_buffer()`.
+  - `ResMut<Events<KeyboardInput>>` → `ResMut<Messages<KeyboardInput>>` in `block_keyboard_input_forwarding()`.
+- `src/command/parser.rs`
+  - `EventReader<ReplSubmitEvent>` → `MessageReader<ReplSubmitEvent>`.
+
+Notes:
+- We already use `.write(...)` on writers, which is correct post-rename. If any `.send_event(...)` appear elsewhere, rename to `.write_message(...)`.
+
+### 2) Observers (Trigger → On) and command events
+- Observer system params must use `On<T>` instead of `Trigger<T>`:
+  - `src/repl.rs`: `fn on_app_exit_emit_disable(_exit: On<AppExit>, …)`.
+  - All examples’ observer functions: `fn on_ping(_t: On<PingCommand>) { … }` etc.
+ - Command events (user-typed commands) remain observer events:
+   - Keep `#[derive(Event)]` for command types like `PingCommand`.
+   - `src/command/register.rs`: For non-generic commands, remove `self.add_event::<C>()` (auto-registered). Keep it only if the type is generic or auto-registration is disabled.
+   - `Commands::trigger(event)` remains valid for observer events.
+
+### 3) Keyboard API
+- No change required for our usage.
+  - We use Crossterm via `bevy_ratatui` for prompt input (`src/prompt/keymap.rs`, `src/prompt/input.rs`).
+  - `ButtonInput<KeyCode>` remains the resource type in Bevy for example hotkeys; variant names like `KeyCode::KeyS`, `KeyCode::ControlLeft` are correct in 0.17.
+
+### 4) AppExit is an observer event
+- In 0.17, `AppExit` is handled via observers and should be triggered, not written as a buffered message.
+  - Use `commands.trigger(AppExit::Success)` from systems (or observers) to exit.
+
+### 5) Dependency considerations
+- `Cargo.toml`: bump `bevy = "0.17"` (keep feature flags equivalent).
+- `bevy_ratatui = "0.9.2"` may target Bevy 0.16. We need a 0.17-compatible version/branch. If unavailable on crates.io, grab a git rev/PR that supports 0.17 or temporarily fork.
+- Other deps (`ratatui`, `tracing`, `clap`) are unaffected by Bevy 0.17.
+
+### 6) Query defaults and Internal filters
+- Default query filter changes: Disabled now filtered by default; add `Allows<Disabled>` where needed.
+- Internal entities hidden by default: add `Allow<Internal>` if you query observers/systems for debugging.
+- Logging path: `repl_println!` macro must be active; avoid double-printing by using one logging strategy at a time.
+
+## Proposed upgrade plan
+ 1. Create branch `bevy-0.17`.
+ 2. Bump Bevy to `0.17` in `Cargo.toml`.
+ 3. Resolve `bevy_ratatui` 0.17 compatibility (use release or git branch/PR).
+ 4. Apply Message renames/derives and `Trigger`→`On` changes per checklist.
+ 5. Replace `AppExit` writer calls with `commands.trigger(AppExit::Success)`.
+ 6. Build; fix compile errors iteratively.
+ 7. Update examples and docs; remove `add_event::<C>()` for non-generic command events.
+ 8. Audit queries for Disabled/Internal filters and adjust where needed.
+ 9. Validate two logging strategies (stdout vs alt-screen) and prompt behavior.
+ 10. Smoke-test commands, prompt input, and observers; then release `0.5.0-alpha`.
+
+## Testing strategy
+- **Commands**: smoke test each registered command triggers its observer.
+- **Prompt**: type input, verify buffer messages and submit message flow.
+- **Logging**: verify expected output for both stdout and alt-screen renderers; ensure no duplicates.
+- **Exit**: verify `commands.trigger(AppExit::Success)` exits cleanly.
+
+## References
+- Migration Guide 0.16→0.17 (Event → Message):
+  - https://bevy.org/learn/migration-guides/0-16-to-0-17/
+- Release notes 0.17 (Observers `On<T>`, Event vs Message):
+- Keyboard input (Key vs KeyCode background):
+  - https://bevy-cheatbook.github.io/input/keyboard.html
+- Tutorial (hooks & observers):
+  - https://youtu.be/BtwNc_sx1pE
+  - https://github.com/rust-adventure/bevy-examples/tree/main/concepts/hooks_and_observers/src/bin
+nd Hooks Cheat Sheet

--- a/doc/notes/2025-10-06-bevy-0.17-migration-spike.md
+++ b/doc/notes/2025-10-06-bevy-0.17-migration-spike.md
@@ -1,0 +1,161 @@
+# Bevy 0.17 Migration Spike - Implementation Notes
+
+Date: 2025-10-06  
+Author: Cascade (AI assistant)
+
+## Summary
+Applied initial Bevy 0.16 → 0.17 migration changes as a spike to identify issues and blockers. Made mechanical changes for the Event→Message refactor and Observer API updates across core modules and selected examples.
+
+## What I Changed
+
+### Core Dependencies
+- `Cargo.toml`: Updated `bevy = "0.17"` but left `bevy_ratatui = "0.9.2"` as-is with a FIXME comment
+
+### Message/Event Refactor
+Applied the buffered event → message pattern:
+- `src/repl.rs`: 
+  - `ReplBufferEvent`, `ReplSubmitEvent`, `ReplLifecycleEvent` now derive `Message`
+  - `add_event` → `add_message` for these types
+  - `EventReader/Writer` → `MessageReader/Writer` for all buffered types
+  - `Trigger<AppExit>` → `On<AppExit>` for the observer
+- `src/log_ecs.rs`:
+  - `LogEvent` now derives `Message`
+  - Updated all readers/writers and registration calls
+- `src/prompt/input.rs`:
+  - Updated all Message readers/writers
+  - `Events<KeyboardInput>` → `Messages<KeyboardInput>` 
+  - Added FIXME for `KeyEvent` from bevy_ratatui
+- `src/command/parser.rs`:
+  - `EventReader<ReplSubmitEvent>` → `MessageReader<ReplSubmitEvent>`
+
+### Observer Updates
+- `src/built_ins/quit.rs`:
+  - `Trigger<QuitCommand>` → `On<QuitCommand>`
+  - Replaced `EventWriter<AppExit>::write()` with `commands.trigger(AppExit::Success)`
+- `src/command/register.rs`:
+  - Added detailed comment about auto-registration but kept `add_event::<C>()` since C is generic
+- Examples (minimal, spawn_entity, query):
+  - Updated observer params from `Trigger<T>` to `On<T>`
+  - Added migration comments
+
+## Troubles & Blockers
+
+### 1. bevy_ratatui Compatibility (CRITICAL BLOCKER)
+- **Issue**: `bevy_ratatui 0.9.2` targets Bevy 0.16, will not compile with 0.17
+- **Impact**: Can't compile or test anything until resolved
+- **Options**:
+  - Check if there's a 0.17-compatible release on crates.io
+  - Use a git branch/PR if one exists
+  - Fork and update it ourselves (significant effort)
+- **Notes**: Left a FIXME comment in Cargo.toml
+
+### 2. KeyEvent Uncertainty
+- **Issue**: `bevy_ratatui::event::KeyEvent` is used in `parse_terminal_input`
+- **Question**: Is this still an `Event` or now a `Message` in bevy_ratatui 0.17?
+- **Location**: `src/prompt/input.rs:104`
+- **Impact**: Won't know until we have a compatible bevy_ratatui
+
+### 3. Auto-registration of Events
+- **Issue**: Bevy 0.17 auto-registers non-generic Event types with reflection
+- **Question**: Can we remove `add_event::<C>()` in `add_repl_command`?
+- **Location**: `src/command/register.rs:17`
+- **Decision**: Kept it with a TODO since C is generic here, but concrete types might not need it
+
+### 4. Incomplete Example Updates
+- **What I did**: Updated 3 representative examples
+- **What remains**: ~16 more examples need `Trigger` → `On` updates
+- **Pattern**: All follow the same pattern, just mechanical changes
+
+## Open Questions
+
+1. **Query Filters**: Do we need to audit for `Allows<Disabled>` or `Allow<Internal>` anywhere?
+   - Haven't seen any queries that would be affected yet
+   - Should do a comprehensive audit once compilation works
+
+2. **Event Auto-registration**: Should we test removing `add_event` for concrete command types?
+   - e.g., `PingCommand`, `QuitCommand` are non-generic
+   - Might simplify the registration code
+
+3. **repl_println! Macro**: Previous notes mention it triggers `compile_error!`
+   - Haven't hit this yet, but may surface once we compile
+   - Related to the logging strategy (stdout vs alt-screen)
+
+4. **Message vs Event for Commands**: Are we sure command events should remain `Event`?
+   - Current assumption: Commands are observer events (immediate), not buffered
+   - This seems correct based on `commands.trigger(event)` usage
+
+## Design Decisions & Considerations
+
+1. **Kept add_event for generic commands**: Since `ReplCommand` is used as a generic type parameter, auto-registration might not work. Kept the manual registration with a detailed comment.
+
+2. **AppExit as observer**: Correctly identified that `AppExit` is now triggered, not written. This is a behavioral change, not just a rename.
+
+3. **Liberal use of comments**: Added MIGRATION comments throughout to explain changes and flag areas that need attention once bevy_ratatui is resolved.
+
+## What You Should Do Next
+
+### Immediate Priority
+1. **Resolve bevy_ratatui blocker**:
+   ```bash
+   # Check for 0.17 version
+   cargo search bevy_ratatui
+   
+   # Check GitHub for PRs/branches
+   # https://github.com/cxreiff/bevy_ratatui
+   ```
+
+2. **If no 0.17 version exists**, consider:
+   - Waiting for official update
+   - Using a fork/PR if available
+   - Creating your own fork (estimate: 2-6 hours of work)
+
+### Once bevy_ratatui is resolved
+1. **Attempt compilation**: 
+   ```bash
+   cargo build --examples
+   ```
+
+2. **Fix remaining compilation errors**:
+   - Likely to find more API changes we haven't caught
+   - Check if `KeyEvent` needs updating
+   - Verify all imports resolve correctly
+
+3. **Complete example updates**:
+   - Apply `Trigger` → `On` to remaining ~16 examples
+   - Test each example for runtime behavior
+
+4. **Testing priorities**:
+   - Basic command execution (`ping`, `quit`)
+   - Buffer events (typing, backspace, submit)
+   - Logging output (both stdout and alt-screen modes)
+   - Query commands to check for filter issues
+
+### Optional Improvements
+1. **Test event auto-registration**: Try removing `add_event` for a concrete type
+2. **Query audit**: Search for queries that might need `Allows<Disabled>`
+3. **Performance testing**: Ensure Message buffering doesn't introduce latency
+
+## Risk Assessment
+
+- **High Risk**: bevy_ratatui compatibility - blocks everything
+- **Medium Risk**: Unknown API changes we haven't discovered yet
+- **Low Risk**: Observer param changes - mechanical and well-understood
+- **Low Risk**: Message/Event refactor - mostly naming, semantics unchanged
+
+## Time Estimate Update
+
+Original estimate: 3-8 hours
+Actual so far: ~1 hour (mechanical changes)
+Remaining:
+- bevy_ratatui resolution: 0.5-6 hours (depending on approach)
+- Compilation fixes: 1-2 hours
+- Testing & validation: 1-2 hours
+- Example completion: 0.5 hours
+
+**Revised total: 4-11 hours**, with bevy_ratatui as the critical path.
+
+## Conclusion
+
+The migration spike successfully identified the patterns and most required changes. The Event→Message refactor is straightforward, and the Observer API changes are mechanical. The main blocker is bevy_ratatui compatibility, which must be resolved before any real testing can begin.
+
+The codebase is well-structured for this migration - the changes are localized and follow consistent patterns. Once the dependency issue is resolved, the remaining work should be straightforward.

--- a/doc/notes/2025-10-06-recommendations-without-bevy_ratatui.md
+++ b/doc/notes/2025-10-06-recommendations-without-bevy_ratatui.md
@@ -1,0 +1,347 @@
+**YES! This is totally achievable** and there are two ways to do it with crossterm:
+
+## Option 1: "Sticky Prompt" Pattern (What You Described)
+
+This keeps the prompt at the bottom while logs scroll above it:
+
+```
+[Game logs scrolling...]
+Enemy spawned at (10, 20)
+Player health: 85
+Resource loaded: texture.png
+                              ← logs scroll here
+>> spawn enemy|               ← prompt STAYS here (cursor position)
+```
+
+### Implementation
+
+```rust
+// src/prompt/render.rs
+use crossterm::{cursor, execute, queue, terminal, style::Print};
+
+#[derive(Resource)]
+pub struct PromptRenderer {
+    prompt_line: u16,  // Which terminal row the prompt is on
+    output_buffer: VecDeque<String>,  // Recent log lines
+    max_output_lines: usize,
+}
+
+impl PromptRenderer {
+    pub fn new() -> Self {
+        let (_, rows) = terminal::size().unwrap();
+        Self {
+            prompt_line: rows - 1,  // Bottom row
+            output_buffer: VecDeque::new(),
+            max_output_lines: 100,
+        }
+    }
+
+    /// Print a log line ABOVE the prompt
+    pub fn print_output(&mut self, line: String) {
+        self.output_buffer.push_back(line);
+        if self.output_buffer.len() > self.max_output_lines {
+            self.output_buffer.pop_front();
+        }
+        self.redraw_all();
+    }
+
+    /// Redraw everything: logs + prompt
+    fn redraw_all(&self) {
+        let mut stdout = io::stdout();
+        
+        // Save current cursor position
+        queue!(stdout, cursor::SavePosition).unwrap();
+
+        // Calculate how many lines of output we can show
+        let visible_lines = self.prompt_line.saturating_sub(1) as usize;
+        let start_idx = self.output_buffer.len().saturating_sub(visible_lines);
+
+        // Draw output lines from top
+        for (i, line) in self.output_buffer.iter().skip(start_idx).enumerate() {
+            queue!(
+                stdout,
+                cursor::MoveTo(0, i as u16),
+                terminal::Clear(terminal::ClearType::CurrentLine),
+                Print(line),
+            ).unwrap();
+        }
+
+        // Restore cursor to prompt line
+        queue!(stdout, cursor::RestorePosition).unwrap();
+        stdout.flush().unwrap();
+    }
+
+    /// Render the prompt line (call every frame)
+    pub fn render_prompt(&self, terminal_state: &TerminalState) {
+        let mut stdout = io::stdout();
+
+        // Always draw on the prompt line
+        queue!(
+            stdout,
+            cursor::MoveTo(0, self.prompt_line),
+            terminal::Clear(terminal::ClearType::CurrentLine),
+            Print(&terminal_state.prompt),
+            Print(&terminal_state.buffer),
+        ).unwrap();
+
+        // Position cursor
+        let cursor_x = (terminal_state.prompt.len() + terminal_state.cursor_pos) as u16;
+        queue!(
+            stdout,
+            cursor::MoveTo(cursor_x, self.prompt_line),
+        ).unwrap();
+
+        stdout.flush().unwrap();
+    }
+}
+```
+
+### Usage in Systems
+
+```rust
+// Print logs system
+fn handle_log_output(
+    mut renderer: ResMut<PromptRenderer>,
+    mut log_reader: MessageReader<LogEvent>,
+) {
+    for log in log_reader.read() {
+        renderer.print_output(format!("[{}] {}", log.level, log.message));
+    }
+}
+
+// Render prompt system (every frame)
+fn render_repl_prompt(
+    renderer: Res<PromptRenderer>,
+    terminal_state: Res<TerminalState>,
+) {
+    renderer.render_prompt(&terminal_state);
+}
+
+// App setup
+app.add_systems(Update, (
+    handle_log_output,
+    render_repl_prompt,
+).chain());
+```
+
+### Visual Effect
+
+```
+INFO: Game started
+DEBUG: Loading assets...
+INFO: Player spawned at (0, 0)
+WARN: Low memory
+INFO: Enemy spawned           ← New log appears here
+>> spawn boss|                ← Prompt stays here (cursor blinks at |)
+```
+
+When a new log comes in, it scrolls up and the prompt redraws at the bottom.
+
+## Option 2: Alt-Screen Mode (Cleaner Separation)
+
+Use crossterm's alternate screen for a true TUI where logs and prompt are completely separate regions:
+
+```rust
+// src/terminal.rs
+pub struct TerminalLayout {
+    output_area: Rect,   // Top region for logs
+    prompt_area: Rect,   // Bottom region for prompt
+}
+
+pub fn setup_terminal(mut commands: Commands) -> Result {
+    let mut stdout = io::stdout();
+    
+    // Enter alternate screen
+    execute!(
+        stdout,
+        terminal::EnterAlternateScreen,
+        cursor::EnableBlinking,
+    )?;
+    terminal::enable_raw_mode()?;
+
+    let (cols, rows) = terminal::size()?;
+    
+    commands.insert_resource(TerminalLayout {
+        output_area: Rect {
+            x: 0,
+            y: 0,
+            width: cols,
+            height: rows - 2,  // Leave 2 rows for prompt + separator
+        },
+        prompt_area: Rect {
+            x: 0,
+            y: rows - 1,
+            width: cols,
+            height: 1,
+        },
+    });
+
+    Ok(())
+}
+
+pub fn render_split_view(
+    layout: Res<TerminalLayout>,
+    logs: Res<LogBuffer>,
+    terminal_state: Res<TerminalState>,
+) {
+    let mut stdout = io::stdout();
+
+    // Draw separator line
+    queue!(
+        stdout,
+        cursor::MoveTo(0, layout.output_area.height),
+        Print("─".repeat(layout.output_area.width as usize)),
+    ).unwrap();
+
+    // Draw logs in output area
+    for (i, line) in logs.recent_lines().iter().enumerate() {
+        if i >= layout.output_area.height as usize {
+            break;
+        }
+        queue!(
+            stdout,
+            cursor::MoveTo(0, i as u16),
+            terminal::Clear(terminal::ClearType::CurrentLine),
+            Print(line),
+        ).unwrap();
+    }
+
+    // Draw prompt in prompt area
+    queue!(
+        stdout,
+        cursor::MoveTo(0, layout.prompt_area.y),
+        terminal::Clear(terminal::ClearType::CurrentLine),
+        Print(&terminal_state.prompt),
+        Print(&terminal_state.buffer),
+        cursor::MoveTo(
+            (terminal_state.prompt.len() + terminal_state.cursor_pos) as u16,
+            layout.prompt_area.y
+        ),
+    ).unwrap();
+
+    stdout.flush().unwrap();
+}
+```
+
+This gives you:
+
+```
+┌────────────────────────────────────┐
+│ INFO: Game started                 │
+│ DEBUG: Loading assets...           │
+│ INFO: Player spawned               │
+│ WARN: Low memory                   │
+│ INFO: Enemy spawned                │ ← Scrollable log area
+│                                    │
+│ (scrolls independently)            │
+├────────────────────────────────────┤ ← Separator
+│ >> spawn boss|                     │ ← Fixed prompt line
+└────────────────────────────────────┘
+```
+
+## 🎯 Which One Should You Use?
+
+### "Sticky Prompt" (Option 1) if:
+- ✅ Want simplicity
+- ✅ Want to stay in normal stdout mode
+- ✅ Don't need to resize dynamically
+- ✅ Okay with logs potentially scrolling off screen
+
+### "Alt-Screen" (Option 2) if:
+- ✅ Want cleaner separation
+- ✅ Need scrollable log history
+- ✅ Want to handle terminal resize gracefully
+- ✅ Okay with full-screen TUI mode
+
+## 💡 Hybrid Approach (Recommended)
+
+Support **both** via a config flag:
+
+```rust
+#[derive(Resource)]
+pub enum ReplDisplayMode {
+    /// Stdout with sticky prompt at bottom
+    StickyPrompt,
+    /// Full alt-screen TUI
+    AlternateScreen,
+}
+
+pub fn render_repl(
+    mode: Res<ReplDisplayMode>,
+    // ... other params
+) {
+    match *mode {
+        ReplDisplayMode::StickyPrompt => render_sticky_prompt(/*...*/),
+        ReplDisplayMode::AlternateScreen => render_alt_screen(/*...*/),
+    }
+}
+```
+
+Let users choose at startup:
+
+```rust
+// Configure via CLI or config file
+ReplPlugin::new()
+    .with_display_mode(ReplDisplayMode::StickyPrompt)
+```
+
+## 🎨 Advanced: Smooth Scrolling Effect
+
+For extra polish with the sticky prompt:
+
+```rust
+impl PromptRenderer {
+    pub fn print_output(&mut self, line: String) {
+        self.output_buffer.push_back(line);
+        
+        // Animate scroll (optional)
+        self.scroll_animation();
+        
+        if self.output_buffer.len() > self.max_output_lines {
+            self.output_buffer.pop_front();
+        }
+    }
+
+    fn scroll_animation(&self) {
+        // Quick scroll effect (optional - looks nice!)
+        for _ in 0..3 {
+            self.redraw_all();
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+}
+```
+
+## 📋 Complete Example: Sticky Prompt System
+
+```rust
+// Full working system
+fn handle_repl_output_with_sticky_prompt(
+    mut renderer: ResMut<PromptRenderer>,
+    mut log_reader: MessageReader<LogEvent>,
+    terminal_state: Res<TerminalState>,
+) {
+    // Process any new logs
+    for log in log_reader.read() {
+        let formatted = format!("[{:5}] {}", log.level, log.message);
+        renderer.print_output(formatted);
+    }
+
+    // Always render the prompt (maintains cursor position)
+    renderer.render_prompt(&terminal_state);
+}
+```
+
+## 🚀 Yes, This Works Great!
+
+The **sticky prompt pattern** (Option 1) gives you exactly what you described:
+- Logs print 1 row above cursor ✅
+- Cursor stays at bottom as input line ✅
+- Logs scroll by naturally ✅
+- Prompt never moves ✅
+
+The implementation is ~150 lines and integrates perfectly with your existing crossterm-based input handling.
+
+---
+
+**My recommendation**: Start with **Option 1 (Sticky Prompt)** for simplicity, then add **Option 2 (Alt-Screen)** as an advanced feature if users want more control over log viewing/scrolling. Both are achievable with the custom crossterm solution!

--- a/doc/notes/2026-03-15-bevy-0.18-migration.md
+++ b/doc/notes/2026-03-15-bevy-0.18-migration.md
@@ -1,0 +1,67 @@
+# Bevy 0.17 → 0.18 Migration Impact for `bevy_repl`
+
+This note summarizes upstream changes, concrete repo impacts, and the upgrade status for Bevy 0.18.
+
+## Summary
+
+The migration to Bevy 0.18 is **relatively straightforward** for `bevy_repl`. The core functionality remains unaffected. Key changes:
+
+- **bevy_ratatui**: Updated from git main to v0.11.1 (Bevy 0.18 compatible)
+- **No breaking API changes** in our code paths
+- **Cargo.toml**: Update dependency version
+
+## What changed upstream
+
+### High Impact
+- **Text API changes**: `TextFont` removed, replaced with separate text style components
+- **Feature renaming**: `animation` → `gltf_animation`, `bevy_*_picking_backend` → `*_picking`
+- **RenderTarget is now a component** (not a field on Camera)
+- **BorderRadius moved to Node** (no longer a separate component)
+- **Entities API changes**: Various `get_components*` methods now return `Result`
+
+### Medium Impact
+- **Schedule cleanup**: Some error types changed
+- **Gizmos**: `cuboid` → `cube`
+- **Input sources under features**: Must enable `keyboard`, `mouse`, etc. explicitly if using `default-features = false`
+
+### Low/No Impact for this repo
+- Most other 0.18 changes (atmosphere, materials, animation) don't affect our use case
+- We don't use custom asset sources
+- We don't use low-level render APIs
+
+## Current Status: ✅ Already Migrated
+
+The project has already been updated:
+
+1. **Cargo.toml** updated:
+   ```toml
+   # Before
+   bevy_ratatui = { git = "https://github.com/ratatui/bevy_ratatui.git", branch = "main", features = ["crossterm"] }
+   
+   # After
+   bevy_ratatui = { version = "0.11", features = ["crossterm"] }
+   ```
+
+2. **Verified**: Project compiles successfully with Bevy 0.18 and bevy_ratatui 0.11.1
+
+## Verification Steps
+
+To verify the migration is complete:
+
+```bash
+cargo check  # Should complete without errors
+cargo build --examples  # Build all examples to ensure they work
+```
+
+## Notes
+
+- The project uses `bevy_ratatui` for terminal UI, which handles the TUI layer
+- Our text output goes through ratatui widgets, not Bevy's native text rendering
+- No changes needed to command system, observers, or event/message flow
+- The 0.17 → 0.18 migration for `bevy_repl` was minimal due to the project's focused scope
+
+## References
+
+- Bevy 0.18 Release Notes: https://bevy.org/news/bevy-0-18/
+- Migration Guide 0.17 → 0.18: https://bevy.org/learn/migration-guides/0-17-to-0-18/
+- bevy_ratatui Releases: https://github.com/ratatui/bevy_ratatui/releases

--- a/examples/aliases.rs
+++ b/examples/aliases.rs
@@ -41,7 +41,7 @@ impl ReplCommand for SayCommand {
 }
 
 // System that handles the command with access to Bevy ECS
-fn on_say(trigger: Trigger<SayCommand>) {
+fn on_say(trigger: On<SayCommand>) {
     let command = trigger.event();
 
     let message = command.message.clone();
@@ -65,9 +65,9 @@ fn instructions() {
 fn main() {
     App::new()
         .add_plugins((
-            DefaultPlugins.set(bevy::app::ScheduleRunnerPlugin::run_loop(std::time::Duration::from_secs_f64(
-                1.0 / 60.0,
-            ))),
+            DefaultPlugins.set(bevy::app::ScheduleRunnerPlugin::run_loop(
+                std::time::Duration::from_secs_f64(1.0 / 60.0),
+            )),
             ReplPlugins,
         ))
         .add_repl_command::<SayCommand>()

--- a/examples/alt_screen.rs
+++ b/examples/alt_screen.rs
@@ -1,5 +1,5 @@
 //! Bevy alternate screen example.
-//! 
+//!
 //! Demonstrates:
 //! - Using RatatuiPlugins in conjunction with ReplPlugins
 //! - Routing Bevy/tracing logs to the REPL
@@ -25,27 +25,27 @@ impl ReplCommand for PingCommand {
     }
 }
 
-fn error_on_ping(_trigger: Trigger<PingCommand>) {
+fn error_on_ping(_trigger: On<PingCommand>) {
     tracing::error!("Pong");
 }
 
-fn warn_on_ping(_trigger: Trigger<PingCommand>) {
+fn warn_on_ping(_trigger: On<PingCommand>) {
     tracing::warn!("Pong");
 }
 
-fn info_on_ping(_trigger: Trigger<PingCommand>) {
+fn info_on_ping(_trigger: On<PingCommand>) {
     tracing::info!("Pong");
 }
 
-fn debug_on_ping(_trigger: Trigger<PingCommand>) {
+fn debug_on_ping(_trigger: On<PingCommand>) {
     tracing::debug!("Pong");
 }
 
-fn trace_on_ping(_trigger: Trigger<PingCommand>) {
+fn trace_on_ping(_trigger: On<PingCommand>) {
     tracing::trace!("Pong");
 }
 
-fn print_on_ping(_trigger: Trigger<PingCommand>) {
+fn print_on_ping(_trigger: On<PingCommand>) {
     repl_println!("(direct print via repl_println!) Pong");
 }
 
@@ -54,9 +54,11 @@ fn main() {
         .add_plugins((
             DefaultPlugins
                 .set(bevy::app::ScheduleRunnerPlugin::run_loop(
-                    std::time::Duration::from_secs_f64(1.0 / 60.0)))
+                    std::time::Duration::from_secs_f64(1.0 / 60.0),
+                ))
                 // Disable the default log plugin, ratatui will handle logs
-                .build().disable::<bevy::log::LogPlugin>(),
+                .build()
+                .disable::<bevy::log::LogPlugin>(),
             bevy_ratatui::RatatuiPlugins::default(),
             ReplPlugins,
         ))

--- a/examples/builder.rs
+++ b/examples/builder.rs
@@ -44,17 +44,22 @@ impl ReplCommand for SayCommand {
 
     fn to_event(matches: &clap::ArgMatches) -> ReplResult<Self> {
         let message = matches.get_one::<String>("message").unwrap().clone();
-        let repeat = matches.get_one::<String>("repeat")
+        let repeat = matches
+            .get_one::<String>("repeat")
             .and_then(|s| s.parse::<usize>().ok())
             .unwrap_or(1);
         let shout = matches.get_flag("shout");
-        
-        Ok(SayCommand { message, repeat, shout })
+
+        Ok(SayCommand {
+            message,
+            repeat,
+            shout,
+        })
     }
 }
 
 // System that handles the command with access to Bevy ECS
-fn on_say(trigger: Trigger<SayCommand>) {
+fn on_say(trigger: On<SayCommand>) {
     let command = trigger.event();
 
     let message = if command.shout {
@@ -64,7 +69,7 @@ fn on_say(trigger: Trigger<SayCommand>) {
     };
     // Print the main message
     repl_println!("Saying: {}", message);
-    
+
     // Print repeated messages
     for i in 0..command.repeat {
         repl_println!("{}: {}", i + 1, message);
@@ -88,9 +93,9 @@ fn instructions() {
 fn main() {
     App::new()
         .add_plugins((
-            DefaultPlugins.set(bevy::app::ScheduleRunnerPlugin::run_loop(std::time::Duration::from_secs_f64(
-                1.0 / 60.0,
-            ))),
+            DefaultPlugins.set(bevy::app::ScheduleRunnerPlugin::run_loop(
+                std::time::Duration::from_secs_f64(1.0 / 60.0),
+            )),
             ReplPlugins,
         ))
         .add_repl_command::<SayCommand>()

--- a/examples/custom_log_layer.rs
+++ b/examples/custom_log_layer.rs
@@ -10,27 +10,27 @@ impl ReplCommand for PingCommand {
     }
 }
 
-fn error_on_ping(_trigger: Trigger<PingCommand>) {
+fn error_on_ping(_trigger: On<PingCommand>) {
     tracing::error!("Pong");
 }
 
-fn warn_on_ping(_trigger: Trigger<PingCommand>) {
+fn warn_on_ping(_trigger: On<PingCommand>) {
     tracing::warn!("Pong");
 }
 
-fn info_on_ping(_trigger: Trigger<PingCommand>) {
+fn info_on_ping(_trigger: On<PingCommand>) {
     tracing::info!("Pong");
 }
 
-fn debug_on_ping(_trigger: Trigger<PingCommand>) {
+fn debug_on_ping(_trigger: On<PingCommand>) {
     tracing::debug!("Pong");
 }
 
-fn trace_on_ping(_trigger: Trigger<PingCommand>) {
+fn trace_on_ping(_trigger: On<PingCommand>) {
     tracing::trace!("Pong");
 }
 
-fn print_on_ping(_trigger: Trigger<PingCommand>) {
+fn print_on_ping(_trigger: On<PingCommand>) {
     repl_println!("(direct print via repl_println!) Pong");
 }
 

--- a/examples/custom_renderer.rs
+++ b/examples/custom_renderer.rs
@@ -53,7 +53,7 @@ impl ReplCommand for PingCommand {
     }
 }
 
-fn on_ping(_: Trigger<PingCommand>) {
+fn on_ping(_: On<PingCommand>) {
     repl_println!("Pong");
 }
 

--- a/examples/default.rs
+++ b/examples/default.rs
@@ -37,7 +37,7 @@ impl ReplCommand for PrintCommand {
 }
 
 // System that handles the command with access to Bevy ECS
-fn on_print(trigger: Trigger<PrintCommand>) {
+fn on_print(trigger: On<PrintCommand>) {
     let command = trigger.event();
     let message = command.message.clone();
     repl_println!("printing: {}", message);
@@ -69,7 +69,7 @@ impl ReplCommand for LogCommand {
 }
 
 // System that handles the command with access to Bevy ECS
-fn on_log(trigger: Trigger<LogCommand>) {
+fn on_log(trigger: On<LogCommand>) {
     let command = trigger.event();
     let message = command.message.clone();
     tracing::info!("logging: {}", message);

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -35,7 +35,7 @@ impl ReplCommand for BackCommand {
     }
 }
 
-fn on_next(_trigger: Trigger<NextCommand>, mut state: ResMut<DemoState>) {
+fn on_next(_trigger: On<NextCommand>, mut state: ResMut<DemoState>) {
     state.step = match state.step {
         DemoStep::Intro => DemoStep::CommandsAndAliases,
         DemoStep::CommandsAndAliases => DemoStep::Logging,
@@ -47,7 +47,7 @@ fn on_next(_trigger: Trigger<NextCommand>, mut state: ResMut<DemoState>) {
     };
 }
 
-fn on_back(_trigger: Trigger<BackCommand>, mut state: ResMut<DemoState>) {
+fn on_back(_trigger: On<BackCommand>, mut state: ResMut<DemoState>) {
     state.step = match state.step {
         DemoStep::Intro => DemoStep::End,
         DemoStep::CommandsAndAliases => DemoStep::Intro,
@@ -171,7 +171,7 @@ impl ReplCommand for SayCommand {
 }
 
 // System that handles the command with access to Bevy ECS
-fn on_say(trigger: Trigger<SayCommand>) {
+fn on_say(trigger: On<SayCommand>) {
     let command = trigger.event();
 
     let message = if command.shout {
@@ -212,13 +212,13 @@ impl ReplCommand for StopCommand {
     }
 }
 
-fn on_start(_t: Trigger<StartCommand>, mut stream: ResMut<LogStream>) {
+fn on_start(_t: On<StartCommand>, mut stream: ResMut<LogStream>) {
     stream.active = true;
     stream.auto_stop = Some(Timer::from_seconds(5.0, TimerMode::Once));
     repl_println!("Log stream started (auto-stop in ~5s). Use `stop` to end early.");
 }
 
-fn on_stop(_t: Trigger<StopCommand>, mut stream: ResMut<LogStream>) {
+fn on_stop(_t: On<StopCommand>, mut stream: ResMut<LogStream>) {
     if stream.active {
         stream.active = false;
         stream.auto_stop = None;
@@ -235,7 +235,7 @@ fn log_streamer(time: Res<Time>, mut stream: ResMut<LogStream>) {
             bevy::log::info!("demo log tick at {:.2}s", time.elapsed_secs());
         }
         if let Some(timer) = stream.auto_stop.as_mut() {
-            if timer.tick(time.delta()).finished() {
+            if timer.tick(time.delta()).is_finished() {
                 stream.active = false;
                 stream.auto_stop = None;
                 repl_println!("Auto-stopped log stream.");
@@ -253,7 +253,7 @@ impl ReplCommand for PingCommand {
     }
 }
 
-fn on_ping(_t: Trigger<PingCommand>) {
+fn on_ping(_t: On<PingCommand>) {
     repl_println!("pong");
 }
 
@@ -277,7 +277,7 @@ impl ReplCommand for SpawnCommand {
         Ok(SpawnCommand { name })
     }
 }
-fn on_spawn(trigger: Trigger<SpawnCommand>, mut commands: Commands) {
+fn on_spawn(trigger: On<SpawnCommand>, mut commands: Commands) {
     let name = trigger.event().name.clone();
     commands.spawn(Name::new(name.clone()));
     repl_println!("Spawned entity '{name}'.");
@@ -290,7 +290,7 @@ impl ReplCommand for ListCommand {
         clap::Command::new("list").about("List all entities with a Name component")
     }
 }
-fn on_list(_t: Trigger<ListCommand>, query: Query<(Entity, &Name)>) {
+fn on_list(_t: On<ListCommand>, query: Query<(Entity, &Name)>) {
     let count = query.iter().count();
     repl_println!("Entities: {}", count);
     for (e, name) in query.iter() {
@@ -317,7 +317,7 @@ impl ReplCommand for QueryCommand {
         Ok(QueryCommand { substring })
     }
 }
-fn on_query(trigger: Trigger<QueryCommand>, query: Query<(Entity, &Name)>) {
+fn on_query(trigger: On<QueryCommand>, query: Query<(Entity, &Name)>) {
     let sub = trigger.event().substring.to_lowercase();
     let mut found = 0usize;
     for (e, name) in query.iter() {
@@ -348,11 +348,7 @@ impl ReplCommand for RemoveCommand {
         Ok(RemoveCommand { substring })
     }
 }
-fn on_remove(
-    trigger: Trigger<RemoveCommand>,
-    mut commands: Commands,
-    query: Query<(Entity, &Name)>,
-) {
+fn on_remove(trigger: On<RemoveCommand>, mut commands: Commands, query: Query<(Entity, &Name)>) {
     let sub = trigger.event().substring.to_lowercase();
     let mut removed = 0usize;
     for (e, name) in query.iter() {
@@ -371,7 +367,7 @@ impl ReplCommand for TimeCommand {
         clap::Command::new("time").about("Show the current time (since startup)")
     }
 }
-fn on_time(_t: Trigger<TimeCommand>, time: Res<Time>) {
+fn on_time(_t: On<TimeCommand>, time: Res<Time>) {
     repl_println!("elapsed: {:.3}s", time.elapsed_secs());
 }
 
@@ -491,7 +487,7 @@ Try:
     remove <substring>  - remove entities with a Name component containing the substring
     time                - get the current time from the Time resource
 
-`next` to proceed. 
+`next` to proceed.
 "#,
             );
         }

--- a/examples/derive.rs
+++ b/examples/derive.rs
@@ -11,21 +11,23 @@ use clap::Parser;
 
 // Define a simple command struct using clap's derive pattern
 #[derive(Parser, ReplCommand, Debug, Clone, Event, Default)]
-#[command(
-    name = "say",
-    about = "Say something"
-)]
+#[command(name = "say", about = "Say something")]
 struct SayCommand {
     #[arg(help = "Message to say")]
     message: String,
-    #[arg(short = 'r', long = "repeat", help = "Number of times to repeat", default_value = "1")]
+    #[arg(
+        short = 'r',
+        long = "repeat",
+        help = "Number of times to repeat",
+        default_value = "1"
+    )]
     repeat: usize,
     #[arg(short = 's', long = "shout", help = "Shout the message", action = clap::ArgAction::SetTrue, num_args = 0)]
     shout: bool,
 }
 
 // System that handles the command with access to Bevy ECS
-fn on_say(trigger: Trigger<SayCommand>) {
+fn on_say(trigger: On<SayCommand>) {
     let command = trigger.event();
 
     let message = if command.shout {
@@ -35,7 +37,7 @@ fn on_say(trigger: Trigger<SayCommand>) {
     };
     // Print the main message
     repl_println!("Saying: {}", message);
-    
+
     // Print repeated messages
     for i in 0..command.repeat {
         repl_println!("{}: {}", i + 1, message);
@@ -59,9 +61,9 @@ fn instructions() {
 fn main() {
     App::new()
         .add_plugins((
-            DefaultPlugins.set(bevy::app::ScheduleRunnerPlugin::run_loop(std::time::Duration::from_secs_f64(
-                1.0 / 60.0,
-            ))),
+            DefaultPlugins.set(bevy::app::ScheduleRunnerPlugin::run_loop(
+                std::time::Duration::from_secs_f64(1.0 / 60.0),
+            )),
             ReplPlugins,
         ))
         .add_repl_command::<SayCommand>()

--- a/examples/fixed_update.rs
+++ b/examples/fixed_update.rs
@@ -67,8 +67,7 @@ struct StartTimerCommand;
 
 impl ReplCommand for StartTimerCommand {
     fn clap_command() -> clap::Command {
-        clap::Command::new("start")
-            .about("Starts the timer")
+        clap::Command::new("start").about("Starts the timer")
     }
 }
 
@@ -77,8 +76,7 @@ struct StopTimerCommand;
 
 impl ReplCommand for StopTimerCommand {
     fn clap_command() -> clap::Command {
-        clap::Command::new("stop")
-            .about("Stops the timer")
+        clap::Command::new("stop").about("Stops the timer")
     }
 }
 
@@ -87,21 +85,20 @@ struct ResetTimerCommand;
 
 impl ReplCommand for ResetTimerCommand {
     fn clap_command() -> clap::Command {
-        clap::Command::new("reset")
-            .about("Resets the timer to 0")
+        clap::Command::new("reset").about("Resets the timer to 0")
     }
 }
 
 // Command handlers
-fn on_start_timer(_trigger: Trigger<StartTimerCommand>, mut timer: ResMut<TimerResource>) {
+fn on_start_timer(_trigger: On<StartTimerCommand>, mut timer: ResMut<TimerResource>) {
     timer.start();
 }
 
-fn on_stop_timer(_trigger: Trigger<StopTimerCommand>, mut timer: ResMut<TimerResource>) {
+fn on_stop_timer(_trigger: On<StopTimerCommand>, mut timer: ResMut<TimerResource>) {
     timer.stop();
 }
 
-fn on_reset_timer(_trigger: Trigger<ResetTimerCommand>, mut timer: ResMut<TimerResource>) {
+fn on_reset_timer(_trigger: On<ResetTimerCommand>, mut timer: ResMut<TimerResource>) {
     timer.reset();
 }
 
@@ -114,17 +111,20 @@ fn display_timer_status(timer: Res<TimerResource>) {
         TimerState::Running => "Running",
         TimerState::Stopped => "Stopped",
     };
-    info!("Timer Status: {} | Elapsed: {:.2} seconds", state_str, timer.elapsed_seconds);
+    info!(
+        "Timer Status: {} | Elapsed: {:.2} seconds",
+        state_str, timer.elapsed_seconds
+    );
 }
 
 // System that increments the timer when running
 fn update_timer(mut timer: ResMut<TimerResource>, time: Res<Time>) {
     if timer.is_running() {
         timer.timer.tick(time.delta());
-        
+
         // Increment elapsed time by the delta time
         timer.elapsed_seconds += time.delta_secs();
-        
+
         // Log every second when running
         if timer.timer.just_finished() {
             info!("Timer: {:.2} seconds", timer.elapsed_seconds);
@@ -145,7 +145,6 @@ fn instructions() {
     repl_println!("Press CTRL+C to exit any time.");
     repl_println!();
 }
-
 
 fn main() {
     App::new()

--- a/examples/keybinds.rs
+++ b/examples/keybinds.rs
@@ -20,7 +20,7 @@ impl ReplCommand for PingCommand {
     }
 }
 
-fn on_ping(_trigger: Trigger<PingCommand>) {
+fn on_ping(_trigger: On<PingCommand>) {
     repl_println!("Pong");
 }
 
@@ -71,7 +71,8 @@ fn detect_bevy_keycode_input(bevy_input: Res<ButtonInput<KeyCode>>) {
 
 fn use_default_keybinds(mut commands: Commands, bevy_input: Res<ButtonInput<KeyCode>>) {
     if bevy_input.any_just_pressed([KeyCode::ControlLeft, KeyCode::ControlRight])
-        && bevy_input.just_pressed(KeyCode::KeyD) {
+        && bevy_input.just_pressed(KeyCode::KeyD)
+    {
         info!("Using default keybinds");
         commands.insert_resource(PromptKeymap::default());
     }
@@ -114,18 +115,20 @@ fn instructions() {
 
 fn main() {
     App::new()
-    .add_plugins((
-        DefaultPlugins.set(bevy::app::ScheduleRunnerPlugin::run_loop(
-            std::time::Duration::from_secs_f64(1.0 / 60.0),
-        )).set(bevy::log::LogPlugin {
-            filter: "info,bevy_repl=trace".to_string(),
-            level: bevy::log::Level::TRACE,
-            ..default()
-        }),
-        ReplPlugins,
-        ExamplePlugin,
-    ))
-    .add_systems(Update, detect_bevy_keycode_input.in_set(ReplSet::Pre))
-    .add_systems(PostStartup, instructions)
-    .run();
+        .add_plugins((
+            DefaultPlugins
+                .set(bevy::app::ScheduleRunnerPlugin::run_loop(
+                    std::time::Duration::from_secs_f64(1.0 / 60.0),
+                ))
+                .set(bevy::log::LogPlugin {
+                    filter: "info,bevy_repl=trace".to_string(),
+                    level: bevy::log::Level::TRACE,
+                    ..default()
+                }),
+            ReplPlugins,
+            ExamplePlugin,
+        ))
+        .add_systems(Update, detect_bevy_keycode_input.in_set(ReplSet::Pre))
+        .add_systems(PostStartup, instructions)
+        .run();
 }

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -24,27 +24,27 @@ impl ReplCommand for PingCommand {
     }
 }
 
-fn error_on_ping(_trigger: Trigger<PingCommand>) {
+fn error_on_ping(_trigger: On<PingCommand>) {
     tracing::error!("Pong");
 }
 
-fn warn_on_ping(_trigger: Trigger<PingCommand>) {
+fn warn_on_ping(_trigger: On<PingCommand>) {
     tracing::warn!("Pong");
 }
 
-fn info_on_ping(_trigger: Trigger<PingCommand>) {
+fn info_on_ping(_trigger: On<PingCommand>) {
     tracing::info!("Pong");
 }
 
-fn debug_on_ping(_trigger: Trigger<PingCommand>) {
+fn debug_on_ping(_trigger: On<PingCommand>) {
     tracing::debug!("Pong");
 }
 
-fn trace_on_ping(_trigger: Trigger<PingCommand>) {
+fn trace_on_ping(_trigger: On<PingCommand>) {
     tracing::trace!("Pong");
 }
 
-fn print_on_ping(_trigger: Trigger<PingCommand>) {
+fn print_on_ping(_trigger: On<PingCommand>) {
     repl_println!("(direct print via repl_println!) Pong");
 }
 

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -18,7 +18,8 @@ impl ReplCommand for PingCommand {
     }
 }
 
-fn on_ping(_trigger: Trigger<PingCommand>) {
+// MIGRATION: Trigger<T> -> On<T> for observer params in Bevy 0.17
+fn on_ping(_trigger: On<PingCommand>) {
     repl_println!("Pong");
 }
 

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,7 +1,7 @@
 //! Minimal Bevy REPL example.
-//! 
+//!
 //! This example shows the minimum amount of dependencies needed to use the REPL.
-//! 
+//!
 //! Demonstrates:
 //! - Registering a simple `ReplCommand` (ping)
 //! - Running headless via `ScheduleRunnerPlugin`
@@ -18,7 +18,6 @@ impl ReplCommand for PingCommand {
     }
 }
 
-// MIGRATION: Trigger<T> -> On<T> for observer params in Bevy 0.17
 fn on_ping(_trigger: On<PingCommand>) {
     repl_println!("Pong");
 }
@@ -37,11 +36,9 @@ fn instructions() {
 fn main() {
     App::new()
         .add_plugins((
-            DefaultPlugins.set(bevy::app::ScheduleRunnerPlugin::run_loop(std::time::Duration::from_secs_f64(
-                1.0 / 60.0,
-            ))),
-            // Input plugin is required so the REPL can handle keyboard input
-            bevy::input::InputPlugin::default(),
+            DefaultPlugins.set(bevy::app::ScheduleRunnerPlugin::run_loop(
+                std::time::Duration::from_secs_f64(1.0 / 60.0),
+            )),
             // Runs the REPL headless in the terminal
             ReplPlugins,
         ))

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -36,7 +36,8 @@ impl ReplCommand for ListCommand {
 }
 
 /// Observer demonstrating a read-only ECS query inside the handler.
-fn on_list(trigger: Trigger<ListCommand>, query: Query<(Entity, Option<&Name>)>) {
+// MIGRATION: Trigger<T> -> On<T> for observer params in Bevy 0.17
+fn on_list(trigger: On<ListCommand>, query: Query<(Entity, Option<&Name>)>) {
     let cmd = trigger.event();
     let needle = cmd.name_contains.as_deref();
 

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -1,5 +1,5 @@
 //! Example showing that observer functions can run ECS Queries.
-//! 
+//!
 //! Demonstrates:
 //! - Using a REPL command derived with clap
 //! - Accessing a `Query` inside the observer function
@@ -36,7 +36,6 @@ impl ReplCommand for ListCommand {
 }
 
 /// Observer demonstrating a read-only ECS query inside the handler.
-// MIGRATION: Trigger<T> -> On<T> for observer params in Bevy 0.17
 fn on_list(trigger: On<ListCommand>, query: Query<(Entity, Option<&Name>)>) {
     let cmd = trigger.event();
     let needle = cmd.name_contains.as_deref();
@@ -80,10 +79,9 @@ fn instructions() {
 fn main() {
     App::new()
         .add_plugins((
-            DefaultPlugins.set(bevy::app::ScheduleRunnerPlugin::run_loop(std::time::Duration::from_secs_f64(
-                1.0 / 60.0,
-            ))),
-            bevy::input::InputPlugin::default(),
+            DefaultPlugins.set(bevy::app::ScheduleRunnerPlugin::run_loop(
+                std::time::Duration::from_secs_f64(1.0 / 60.0),
+            )),
             ReplPlugins,
         ))
         .add_repl_command::<ListCommand>()

--- a/examples/show_prompt_actions.rs
+++ b/examples/show_prompt_actions.rs
@@ -1,4 +1,3 @@
-
 use bevy::prelude::*;
 use bevy_repl::prelude::*;
 
@@ -11,27 +10,27 @@ impl ReplCommand for PingCommand {
     }
 }
 
-fn error_on_ping(_trigger: Trigger<PingCommand>) {
+fn error_on_ping(_trigger: On<PingCommand>) {
     tracing::error!("Pong");
 }
 
-fn warn_on_ping(_trigger: Trigger<PingCommand>) {
+fn warn_on_ping(_trigger: On<PingCommand>) {
     tracing::warn!("Pong");
 }
 
-fn info_on_ping(_trigger: Trigger<PingCommand>) {
+fn info_on_ping(_trigger: On<PingCommand>) {
     tracing::info!("Pong");
 }
 
-fn debug_on_ping(_trigger: Trigger<PingCommand>) {
+fn debug_on_ping(_trigger: On<PingCommand>) {
     tracing::debug!("Pong");
 }
 
-fn trace_on_ping(_trigger: Trigger<PingCommand>) {
+fn trace_on_ping(_trigger: On<PingCommand>) {
     tracing::trace!("Pong");
 }
 
-fn print_on_ping(_trigger: Trigger<PingCommand>) {
+fn print_on_ping(_trigger: On<PingCommand>) {
     repl_println!("(direct print via repl_println!) Pong");
 }
 
@@ -48,13 +47,15 @@ fn instructions() {
 fn main() {
     App::new()
         .add_plugins((
-            DefaultPlugins.set(bevy::app::ScheduleRunnerPlugin::run_loop(
-                std::time::Duration::from_secs_f64(1.0 / 60.0),
-            )).set(bevy::log::LogPlugin {
-                filter: "info,bevy_repl=trace".to_string(),
-                level: bevy::log::Level::TRACE,
-                ..default()
-            }),
+            DefaultPlugins
+                .set(bevy::app::ScheduleRunnerPlugin::run_loop(
+                    std::time::Duration::from_secs_f64(1.0 / 60.0),
+                ))
+                .set(bevy::log::LogPlugin {
+                    filter: "info,bevy_repl=trace".to_string(),
+                    level: bevy::log::Level::TRACE,
+                    ..default()
+                }),
             ReplPlugins,
         ))
         .add_repl_command::<PingCommand>()

--- a/examples/spawn_entity.rs
+++ b/examples/spawn_entity.rs
@@ -1,5 +1,5 @@
 //! Command example that spawns an entity via the REPL.
-//! 
+//!
 //! Demonstrates:
 //! - Defining a command with clap's derive macros
 //! - Automatic `ReplCommand` via `#[derive(ReplCommand)]`
@@ -36,7 +36,6 @@ impl ReplCommand for SpawnEntityCommand {
 }
 
 /// Observer that handles the `spawn` command and spawns into the ECS.
-// MIGRATION: Trigger<T> -> On<T> for observer params in Bevy 0.17
 fn on_spawn(trigger: On<SpawnEntityCommand>, mut commands: Commands) {
     let cmd = trigger.event();
 
@@ -66,10 +65,9 @@ fn instructions() {
 fn main() {
     App::new()
         .add_plugins((
-            DefaultPlugins.set(bevy::app::ScheduleRunnerPlugin::run_loop(std::time::Duration::from_secs_f64(
-                1.0 / 60.0,
-            ))),
-            bevy::input::InputPlugin::default(),
+            DefaultPlugins.set(bevy::app::ScheduleRunnerPlugin::run_loop(
+                std::time::Duration::from_secs_f64(1.0 / 60.0),
+            )),
             ReplPlugins,
         ))
         .add_repl_command::<SpawnEntityCommand>()

--- a/examples/spawn_entity.rs
+++ b/examples/spawn_entity.rs
@@ -36,7 +36,8 @@ impl ReplCommand for SpawnEntityCommand {
 }
 
 /// Observer that handles the `spawn` command and spawns into the ECS.
-fn on_spawn(trigger: Trigger<SpawnEntityCommand>, mut commands: Commands) {
+// MIGRATION: Trigger<T> -> On<T> for observer params in Bevy 0.17
+fn on_spawn(trigger: On<SpawnEntityCommand>, mut commands: Commands) {
     let cmd = trigger.event();
 
     // Build the entity

--- a/examples/update_resource.rs
+++ b/examples/update_resource.rs
@@ -65,7 +65,7 @@ impl ReplCommand for TimeScaleCommand {
 }
 
 // -------- Observer that mutates the resource --------
-fn on_time_scale(trigger: Trigger<TimeScaleCommand>, mut scale: ResMut<TimeScale>) {
+fn on_time_scale(trigger: On<TimeScaleCommand>, mut scale: ResMut<TimeScale>) {
     let cmd = trigger.event();
 
     match (cmd.set, cmd.add) {
@@ -123,8 +123,6 @@ fn main() {
             DefaultPlugins.set(bevy::app::ScheduleRunnerPlugin::run_loop(
                 std::time::Duration::from_secs_f64(1.0 / 60.0),
             )),
-            // Required so the REPL can handle keyboard input
-            bevy::input::InputPlugin::default(),
             ReplPlugins,
         ))
         .add_repl_command::<TimeScaleCommand>()

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -14,7 +14,7 @@ impl ReplCommand for PingCommand {
     }
 }
 
-fn on_ping(_trigger: Trigger<PingCommand>) {
+fn on_ping(_trigger: On<PingCommand>) {
     info!("Pong");
 }
 

--- a/src/built_ins/clear.rs
+++ b/src/built_ins/clear.rs
@@ -1,5 +1,6 @@
-use bevy::prelude::*;
+use crate::context::ReplContext;
 use crate::prelude::*;
+use bevy::prelude::*;
 
 pub fn plugin(app: &mut App) {
     app.add_repl_command::<ClearCommand>();
@@ -15,7 +16,7 @@ impl crate::command::ReplCommand for ClearCommand {
     }
 }
 
-fn on_clear(_trigger: Trigger<ClearCommand>, mut terminal: ResMut<FallbackTerminalContext>) {
+fn on_clear(_trigger: On<ClearCommand>, mut terminal: ResMut<ReplContext>) {
     match terminal.clear() {
         Ok(_) => return,
         Err(e) => error!("Failed to clear terminal: {}", e),

--- a/src/built_ins/help.rs
+++ b/src/built_ins/help.rs
@@ -1,6 +1,6 @@
-use bevy::prelude::*;
 use crate::prelude::*;
 use crate::repl_println;
+use bevy::prelude::*;
 
 pub fn plugin(app: &mut App) {
     app.add_repl_command::<HelpCommand>();
@@ -16,6 +16,6 @@ impl crate::command::ReplCommand for HelpCommand {
     }
 }
 
-fn on_help(_t: Trigger<HelpCommand>) {
+fn on_help(_t: On<HelpCommand>) {
     repl_println!("not implemented, sorry");
 }

--- a/src/built_ins/mod.rs
+++ b/src/built_ins/mod.rs
@@ -3,10 +3,10 @@ use bevy::prelude::*;
 #[cfg(feature = "quit")]
 mod quit;
 
-#[cfg(feature="clear")]
+#[cfg(feature = "clear")]
 mod clear;
 
-#[cfg(feature="help")]
+#[cfg(feature = "help")]
 mod help;
 
 pub struct ReplDefaultCommandsPlugin;

--- a/src/built_ins/quit.rs
+++ b/src/built_ins/quit.rs
@@ -18,6 +18,9 @@ impl crate::command::ReplCommand for QuitCommand {
     }
 }
 
-fn on_quit(_trigger: Trigger<QuitCommand>, mut exit: EventWriter<AppExit>) {
-    exit.write(AppExit::Success);
+// MIGRATION: Two changes here:
+// 1. Trigger<T> -> On<T> for observer params
+// 2. AppExit is now an observer event, use Commands::trigger instead of EventWriter
+fn on_quit(_trigger: On<QuitCommand>, mut commands: Commands) {
+    commands.trigger(AppExit::Success);
 }

--- a/src/built_ins/quit.rs
+++ b/src/built_ins/quit.rs
@@ -18,9 +18,6 @@ impl crate::command::ReplCommand for QuitCommand {
     }
 }
 
-// MIGRATION: Two changes here:
-// 1. Trigger<T> -> On<T> for observer params
-// 2. AppExit is now an observer event, use Commands::trigger instead of EventWriter
-fn on_quit(_trigger: On<QuitCommand>, mut commands: Commands) {
-    commands.trigger(AppExit::Success);
+fn on_quit(_trigger: On<QuitCommand>, mut exit: MessageWriter<AppExit>) {
+    exit.write(AppExit::Success);
 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -4,13 +4,17 @@ use bevy::prelude::*;
 pub mod parser;
 pub mod register;
 
-pub use parser::{ParserPlugin, CommandParser, TypedCommandParser, parse_input_buffer_for_commands};
-pub use register::{ReplAppExt, register_command_in_repl};
+pub use parser::{
+    parse_input_buffer_for_commands, CommandParser, ParserPlugin, TypedCommandParser,
+};
+pub use register::{register_command_in_repl, ReplAppExt};
 
 pub type ReplResult<T> = Result<T, clap::error::Error>;
 
 /// Trait for commands that can be registered with the REPL
-pub trait ReplCommand: Send + Sync + Clone + Event + Default + 'static {
+pub trait ReplCommand:
+    Send + Sync + Clone + Event<Trigger<'static>: Default> + Default + 'static
+{
     /// Returns the clap::Command definition for this command
     fn clap_command() -> clap::Command;
 
@@ -25,5 +29,175 @@ pub trait ReplCommand: Send + Sync + Clone + Event + Default + 'static {
         Self: Sized,
     {
         Self::clap_command().try_get_matches_from(args)
+    }
+}
+
+#[cfg(test)]
+mod command_tests {
+    use super::*;
+
+    #[derive(Debug, Clone, Event, Default)]
+    #[allow(dead_code)]
+    struct TestCommand {
+        pub message: Option<String>,
+        pub count: u32,
+    }
+
+    impl ReplCommand for TestCommand {
+        fn clap_command() -> clap::Command {
+            clap::Command::new("test")
+                .about("A test command")
+                .arg(clap::Arg::new("message").help("Message to print"))
+        }
+
+        fn to_event(matches: &clap::ArgMatches) -> ReplResult<Self> {
+            Ok(Self {
+                message: matches.get_one::<String>("message").cloned(),
+                count: 0,
+            })
+        }
+    }
+
+    #[test]
+    fn test_command_registration() {
+        let cmd = TestCommand::clap_command();
+        assert_eq!(cmd.get_name(), "test");
+    }
+
+    #[test]
+    fn test_command_parsing_with_args() {
+        let argv = shell_words::split("test hello").unwrap();
+        let cmd = TestCommand::clap_command();
+        let result = cmd.try_get_matches_from(&argv);
+        assert!(result.is_ok(), "Should parse args successfully");
+        let matches = result.unwrap();
+        assert_eq!(matches.get_one::<String>("message").unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_command_parsing_multiple_args_fails() {
+        let argv = shell_words::split("test hello world").unwrap();
+        let cmd = TestCommand::clap_command();
+        let result = cmd.try_get_matches_from(&argv);
+        // Should fail because "world" is an extra argument
+        assert!(result.is_err(), "Should fail with extra args");
+    }
+
+    #[test]
+    fn test_command_parsing_no_args() {
+        let argv = shell_words::split("test").unwrap();
+        let cmd = TestCommand::clap_command();
+        let result = cmd.try_get_matches_from(&argv);
+        assert!(result.is_ok(), "Should parse command with no args");
+    }
+
+    #[test]
+    fn test_shell_words_parsing() {
+        use shell_words::split;
+
+        let result = split("test hello world").unwrap();
+        assert_eq!(result, vec!["test", "hello", "world"]);
+
+        let result = split("test \"hello world\"").unwrap();
+        assert_eq!(result, vec!["test", "hello world"]);
+
+        let result = split("test hello\\ world").unwrap();
+        assert_eq!(result, vec!["test", "hello world"]);
+    }
+}
+
+#[cfg(test)]
+mod repl_buffer_tests {
+    use crate::repl::Repl;
+
+    #[test]
+    fn test_repl_buffer_insert() {
+        let mut repl = Repl::default();
+        repl.insert('h');
+        repl.insert('i');
+        assert_eq!(repl.buffer, "hi");
+        assert_eq!(repl.cursor_pos, 2);
+    }
+
+    #[test]
+    fn test_repl_buffer_backspace() {
+        let mut repl = Repl::default();
+        repl.insert('h');
+        repl.insert('i');
+        repl.backspace();
+        assert_eq!(repl.buffer, "h");
+        assert_eq!(repl.cursor_pos, 1);
+    }
+
+    #[test]
+    fn test_repl_buffer_delete() {
+        let mut repl = Repl::default();
+        repl.insert('h');
+        repl.insert('i');
+        // Move cursor back to position 1, then delete removes 'i'
+        repl.left();
+        repl.delete();
+        assert_eq!(repl.buffer, "h");
+    }
+
+    #[test]
+    fn test_repl_buffer_left_right() {
+        let mut repl = Repl::default();
+        repl.insert('h');
+        repl.insert('i');
+        repl.left();
+        assert_eq!(repl.cursor_pos, 1);
+        repl.insert('s');
+        assert_eq!(repl.buffer, "hsi");
+        repl.right();
+        assert_eq!(repl.cursor_pos, 3);
+    }
+
+    #[test]
+    fn test_repl_buffer_home_end() {
+        let mut repl = Repl::default();
+        repl.insert('h');
+        repl.insert('i');
+        repl.home();
+        assert_eq!(repl.cursor_pos, 0);
+        repl.end();
+        assert_eq!(repl.cursor_pos, 2);
+    }
+
+    #[test]
+    fn test_repl_buffer_clear() {
+        let mut repl = Repl::default();
+        repl.insert('h');
+        repl.insert('i');
+        repl.clear_buffer();
+        assert!(repl.buffer.is_empty());
+        assert_eq!(repl.cursor_pos, 0);
+    }
+
+    #[test]
+    fn test_repl_buffer_drain() {
+        let mut repl = Repl::default();
+        repl.insert('h');
+        repl.insert('i');
+        let drained = repl.drain_buffer();
+        assert_eq!(drained, "hi");
+        assert!(repl.buffer.is_empty());
+    }
+
+    #[test]
+    fn test_repl_buffer_bounds() {
+        let mut repl = Repl::default();
+
+        repl.backspace();
+        assert_eq!(repl.cursor_pos, 0);
+
+        repl.insert('h');
+        repl.right();
+        assert_eq!(repl.cursor_pos, 1);
+        repl.right();
+        assert_eq!(repl.cursor_pos, 1);
+
+        repl.delete();
+        assert_eq!(repl.buffer, "h");
     }
 }

--- a/src/command/parser.rs
+++ b/src/command/parser.rs
@@ -86,8 +86,9 @@ impl<C: ReplCommand> CommandParser for TypedCommandParser<C> {
 }
 
 /// System that parses terminal input and triggers command observers
+// MIGRATION: EventReader -> MessageReader for buffered events
 pub fn parse_input_buffer_for_commands(
-    mut submitted_text: EventReader<ReplSubmitEvent>,
+    mut submitted_text: MessageReader<ReplSubmitEvent>,
     mut bevy_commands: Commands,
     repl: Res<Repl>,
 ) {

--- a/src/command/parser.rs
+++ b/src/command/parser.rs
@@ -1,8 +1,8 @@
-use bevy::prelude::*;
-use bevy_ratatui::event::InputSet;
+use super::ReplCommand;
 use crate::repl::{Repl, ReplSubmitEvent};
 use crate::repl_println;
-use super::ReplCommand;
+use bevy::prelude::*;
+use bevy_ratatui::event::InputSet;
 pub struct ParserPlugin;
 
 impl Plugin for ParserPlugin {
@@ -86,7 +86,6 @@ impl<C: ReplCommand> CommandParser for TypedCommandParser<C> {
 }
 
 /// System that parses terminal input and triggers command observers
-// MIGRATION: EventReader -> MessageReader for buffered events
 pub fn parse_input_buffer_for_commands(
     mut submitted_text: MessageReader<ReplSubmitEvent>,
     mut bevy_commands: Commands,
@@ -113,7 +112,10 @@ pub fn parse_input_buffer_for_commands(
         if let Some(parser) = repl.commands.get(key) {
             let _ = parser.parse_and_trigger(&input, &mut bevy_commands);
         } else {
-            error!("Unknown command '{}'", input);
+            error!(
+                "Unknown command '{}'. Type 'help' to see available commands.",
+                key
+            );
         }
     }
 }

--- a/src/command/register.rs
+++ b/src/command/register.rs
@@ -10,7 +10,10 @@ pub trait ReplAppExt {
 
 impl ReplAppExt for App {
     fn add_repl_command<C: ReplCommand>(&mut self) -> &mut Self {
-        // Add the command event type
+        // MIGRATION: In Bevy 0.17, non-generic Event types are auto-registered
+        // We're keeping this for now as C is generic here, but specific implementations
+        // might not need it if reflect_auto_register is enabled (default)
+        // TODO: Test if this can be removed once bevy_ratatui is 0.17-compatible
         self.add_event::<C>();
 
         // Register command in the REPL

--- a/src/command/register.rs
+++ b/src/command/register.rs
@@ -1,6 +1,6 @@
-use bevy::prelude::*;
+use super::{CommandParser, ReplCommand, TypedCommandParser};
 use crate::repl::Repl;
-use super::{ReplCommand, TypedCommandParser, CommandParser};
+use bevy::prelude::*;
 
 /// Extension trait for App to add REPL commands
 pub trait ReplAppExt {
@@ -10,15 +10,7 @@ pub trait ReplAppExt {
 
 impl ReplAppExt for App {
     fn add_repl_command<C: ReplCommand>(&mut self) -> &mut Self {
-        // MIGRATION: In Bevy 0.17, non-generic Event types are auto-registered
-        // We're keeping this for now as C is generic here, but specific implementations
-        // might not need it if reflect_auto_register is enabled (default)
-        // TODO: Test if this can be removed once bevy_ratatui is 0.17-compatible
-        self.add_event::<C>();
-
-        // Register command in the REPL
         self.add_systems(Startup, register_command_in_repl::<C>);
-
         self
     }
 }
@@ -28,8 +20,10 @@ pub fn register_command_in_repl<C: ReplCommand>(mut repl: ResMut<Repl>) {
     let cmd = C::clap_command();
     let primary = cmd.get_name().to_string();
     // Insert primary name
-    repl.commands
-        .insert(primary, Box::new(TypedCommandParser::<C>::new()) as Box<dyn CommandParser>);
+    repl.commands.insert(
+        primary,
+        Box::new(TypedCommandParser::<C>::new()) as Box<dyn CommandParser>,
+    );
     // Insert all aliases (visible/invisible)
     for alias in cmd.get_all_aliases() {
         repl.commands.insert(

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,8 +1,9 @@
 use bevy::prelude::*;
 use bevy_ratatui::{
     crossterm::{
-        ExecutableCommand, cursor,
+        cursor,
         terminal::{disable_raw_mode, enable_raw_mode},
+        ExecutableCommand,
     },
     error::ErrorPlugin,
     event::EventPlugin,
@@ -14,8 +15,8 @@ use color_eyre::{
     config::{EyreHook, HookBuilder, PanicHook},
     eyre,
 };
-use ratatui::{Terminal, backend::CrosstermBackend};
-use std::io::{Stdout, stdout};
+use ratatui::{backend::CrosstermBackend, Terminal};
+use std::io::{stdout, Stdout};
 use std::panic;
 
 /// The plugin behaves like a [`RatatuiContext`] but for [`ReplContext`]. It
@@ -47,7 +48,7 @@ impl Plugin for ReplContextPlugin {
         // Replicates the bevy_ratatui ContextPlugin
         app.add_systems(Startup, context_setup);
         // Replicates the bevy_ratatui CleanupPlugin
-        app.add_observer(context_cleanup);
+        app.add_systems(Last, context_cleanup);
     }
 }
 
@@ -75,7 +76,13 @@ impl ReplContext {
     }
 
     fn restore() -> Result<()> {
+        use std::io::Write;
         let mut stdout = stdout();
+        // Reset scroll region (DECSTBM) in case it was set
+        let _ = write!(stdout, "\x1B[r");
+        // Move cursor to a new line so the shell prompt doesn't overlap
+        let _ = write!(stdout, "\r\n");
+        let _ = stdout.flush();
         stdout.execute(cursor::Show)?;
         disable_raw_mode()?;
         Ok(())
@@ -93,9 +100,11 @@ pub fn context_setup(mut commands: Commands) -> Result {
 /// Equivalent to what [`CleanupPlugin`] does, but for the REPL context. (The
 /// regular cleanup plugin will remove [`RatatuiContext`] resources but not
 /// [`ReplContext`] so we have to do it ourselves.)
-fn context_cleanup(_trigger: Trigger<AppExit>, mut commands: Commands) {
-    commands.remove_resource::<KittyEnabled>();
-    commands.remove_resource::<ReplContext>();
+fn context_cleanup(mut exit: MessageReader<AppExit>, mut commands: Commands) {
+    for _ in exit.read() {
+        commands.remove_resource::<KittyEnabled>();
+        commands.remove_resource::<ReplContext>();
+    }
 }
 
 /// Installs hooks for panic and error handling. This is a ripoff of the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,12 +30,12 @@ pub mod prelude {
     pub use crate::command::ReplCommand;
     pub use crate::command::{ReplAppExt, ReplResult};
     pub use crate::prompt::{
-        PromptPlugin, ReplPrompt, ReplPromptConfig,
-        renderer::{ActiveRenderer, PromptRenderPlugin, PromptRenderer, simple::SimpleRenderer},
         keymap::{Binding as ReplKeybind, PromptKeymap},
+        renderer::{simple::SimpleRenderer, ActiveRenderer, PromptRenderPlugin, PromptRenderer},
+        PromptPlugin, ReplPrompt, ReplPromptConfig,
     };
     pub use crate::repl::{
-        Repl, ReplBufferEvent, ReplPlugin, ReplSet, ReplSubmitEvent, repl_is_enabled,
+        repl_is_enabled, Repl, ReplBufferEvent, ReplPlugin, ReplSet, ReplSubmitEvent,
     };
     // Bring the robust printing macro into the prelude for convenient use.
     // This allows: `use bevy_repl::prelude::*;` then `repl_println!(...)`.
@@ -45,8 +45,8 @@ pub mod prelude {
 
     pub use crate::context::ReplContextPlugin;
     pub use crate::log_ecs::{
-        LogEvent, custom_layer as repl_log_custom_layer, print_log_events_system,
-        tracing_to_repl_fmt, tracing_to_repl_fmt_with_level,
+        custom_layer as repl_log_custom_layer, print_log_events_system, tracing_to_repl_fmt,
+        tracing_to_repl_fmt_with_level, LogEvent,
     };
     pub use crate::plugin::ReplPlugins;
 
@@ -54,7 +54,10 @@ pub mod prelude {
     pub use bevy_repl_derive::ReplCommand;
 
     // re-exports for convenience
-    pub use bevy_ratatui::crossterm::event::{KeyCode as CrosstermKey, KeyModifiers as CrosstermMods};
+    pub use bevy_ratatui::crossterm::event::{
+        KeyCode as CrosstermKey, KeyModifiers as CrosstermMods,
+    };
+    pub use bevy_ratatui::event::KeyMessage;
 }
 
 // re-export at the root for convenience

--- a/src/log_ecs.rs
+++ b/src/log_ecs.rs
@@ -91,7 +91,7 @@ pub fn custom_layer(app: &mut App) -> Option<BoxedLayer> {
     let (sender, receiver) = mpsc::channel();
     let layer = CaptureLayer { sender };
 
-    app.insert_non_send_resource(CapturedLogEvents(receiver));
+    app.insert_non_send(CapturedLogEvents(receiver));
     app.add_message::<LogEvent>();
     app.add_systems(Update, transfer_log_events.in_set(ReplSet::Pre));
 

--- a/src/log_ecs.rs
+++ b/src/log_ecs.rs
@@ -3,12 +3,12 @@
 
 use std::sync::mpsc;
 
-use bevy::prelude::*;
 use bevy::log::{
     tracing::{self, Subscriber},
     tracing_subscriber::{self as ts, Layer},
     BoxedLayer,
 };
+use bevy::prelude::*;
 
 use crate::repl::ReplSet;
 
@@ -25,7 +25,6 @@ impl Plugin for ReplLogPrintPlugin {
             // screen.
             tracing_to_repl_fmt();
         }
-        // MIGRATION: LogEvent is a buffered event, now a Message in 0.17
         app.add_message::<LogEvent>();
         app.add_systems(
             Update,
@@ -38,7 +37,6 @@ impl Plugin for ReplLogPrintPlugin {
 }
 
 /// Event emitted into the ECS for each tracing log event captured by the layer.
-// MIGRATION: Changed from Event to Message - this is a buffered event
 #[derive(Message, Clone)]
 pub struct LogEvent {
     pub message: String,
@@ -49,7 +47,6 @@ pub struct LogEvent {
 pub struct CapturedLogEvents(pub mpsc::Receiver<LogEvent>);
 
 /// Transfer all currently available items from the mpsc receiver into the ECS event queue.
-// MIGRATION: EventWriter -> MessageWriter for buffered events
 pub fn transfer_log_events(
     mut log_events: MessageWriter<LogEvent>,
     receiver: NonSend<CapturedLogEvents>,
@@ -69,8 +66,11 @@ impl<S: Subscriber> Layer<S> for CaptureLayer {
         event.record(&mut CaptureLayerVisitor(&mut message));
         if let Some(message) = message {
             let metadata = event.metadata();
-            // MIGRATION: LogEvent is now a Message, still sent via mpsc (no change needed here)
-            let _ = self.sender.send(LogEvent { message, level: *metadata.level() });
+
+            let _ = self.sender.send(LogEvent {
+                message,
+                level: *metadata.level(),
+            });
         }
     }
 }
@@ -92,7 +92,6 @@ pub fn custom_layer(app: &mut App) -> Option<BoxedLayer> {
     let layer = CaptureLayer { sender };
 
     app.insert_non_send_resource(CapturedLogEvents(receiver));
-    // MIGRATION: LogEvent is a buffered event, now a Message in 0.17
     app.add_message::<LogEvent>();
     app.add_systems(Update, transfer_log_events.in_set(ReplSet::Pre));
 
@@ -101,7 +100,6 @@ pub fn custom_layer(app: &mut App) -> Option<BoxedLayer> {
 
 /// Convenience system that prints captured `LogEvent`s via the REPL printer so they appear
 /// correctly above the prompt.
-// MIGRATION: EventReader -> MessageReader for buffered events
 pub fn print_log_events_system(mut events: MessageReader<LogEvent>) {
     use crate::repl_println;
     for ev in events.read() {
@@ -118,11 +116,15 @@ struct ReplMakeWriter;
 
 impl ts::fmt::MakeWriter<'_> for ReplMakeWriter {
     type Writer = ReplWriter;
-    fn make_writer(&self) -> Self::Writer { ReplWriter::default() }
+    fn make_writer(&self) -> Self::Writer {
+        ReplWriter::default()
+    }
 }
 
 #[derive(Default)]
-struct ReplWriter { buf: String }
+struct ReplWriter {
+    buf: String,
+}
 
 impl std::io::Write for ReplWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
@@ -156,8 +158,8 @@ pub fn tracing_to_repl_fmt() {
 /// Same as `install_tracing_to_repl_fmt`, but lets you choose the max log level
 /// (to mirror the `level` used by Bevy's `LogPlugin`).
 pub fn tracing_to_repl_fmt_with_level(level: bevy::log::Level) {
-    use ts::{fmt, prelude::*, registry::Registry};
     use ts::filter::LevelFilter;
+    use ts::{fmt, prelude::*, registry::Registry};
 
     let lf = match level {
         bevy::log::Level::ERROR => LevelFilter::ERROR,

--- a/src/log_ecs.rs
+++ b/src/log_ecs.rs
@@ -25,7 +25,8 @@ impl Plugin for ReplLogPrintPlugin {
             // screen.
             tracing_to_repl_fmt();
         }
-        app.add_event::<LogEvent>();
+        // MIGRATION: LogEvent is a buffered event, now a Message in 0.17
+        app.add_message::<LogEvent>();
         app.add_systems(
             Update,
             print_log_events_system
@@ -37,7 +38,8 @@ impl Plugin for ReplLogPrintPlugin {
 }
 
 /// Event emitted into the ECS for each tracing log event captured by the layer.
-#[derive(Event, Clone)]
+// MIGRATION: Changed from Event to Message - this is a buffered event
+#[derive(Message, Clone)]
 pub struct LogEvent {
     pub message: String,
     pub level: tracing::Level,
@@ -47,8 +49,9 @@ pub struct LogEvent {
 pub struct CapturedLogEvents(pub mpsc::Receiver<LogEvent>);
 
 /// Transfer all currently available items from the mpsc receiver into the ECS event queue.
+// MIGRATION: EventWriter -> MessageWriter for buffered events
 pub fn transfer_log_events(
-    mut log_events: EventWriter<LogEvent>,
+    mut log_events: MessageWriter<LogEvent>,
     receiver: NonSend<CapturedLogEvents>,
 ) {
     log_events.write_batch(receiver.0.try_iter());
@@ -66,6 +69,7 @@ impl<S: Subscriber> Layer<S> for CaptureLayer {
         event.record(&mut CaptureLayerVisitor(&mut message));
         if let Some(message) = message {
             let metadata = event.metadata();
+            // MIGRATION: LogEvent is now a Message, still sent via mpsc (no change needed here)
             let _ = self.sender.send(LogEvent { message, level: *metadata.level() });
         }
     }
@@ -88,7 +92,8 @@ pub fn custom_layer(app: &mut App) -> Option<BoxedLayer> {
     let layer = CaptureLayer { sender };
 
     app.insert_non_send_resource(CapturedLogEvents(receiver));
-    app.add_event::<LogEvent>();
+    // MIGRATION: LogEvent is a buffered event, now a Message in 0.17
+    app.add_message::<LogEvent>();
     app.add_systems(Update, transfer_log_events.in_set(ReplSet::Pre));
 
     Some(layer.boxed())
@@ -96,7 +101,8 @@ pub fn custom_layer(app: &mut App) -> Option<BoxedLayer> {
 
 /// Convenience system that prints captured `LogEvent`s via the REPL printer so they appear
 /// correctly above the prompt.
-pub fn print_log_events_system(mut events: EventReader<LogEvent>) {
+// MIGRATION: EventReader -> MessageReader for buffered events
+pub fn print_log_events_system(mut events: MessageReader<LogEvent>) {
     use crate::repl_println;
     for ev in events.read() {
         repl_println!("{:5} {}", ev.level, ev.message);

--- a/src/print.rs
+++ b/src/print.rs
@@ -1,5 +1,5 @@
 //! Simple, robust printing helpers suitable for raw/alternate screen.
-//! 
+//!
 //! Use the `repl_println!` macro to print a formatted line that:
 //! - moves the cursor to column 0
 //! - writes the formatted content
@@ -9,10 +9,10 @@
 //! This avoids newline/cursor issues that can happen in raw or alternate screen modes.
 
 use std::io::{stdout, Write};
-use std::sync::atomic::{AtomicU64, AtomicU16, Ordering};
+use std::sync::atomic::{AtomicU16, AtomicU64, Ordering};
 
 use bevy_ratatui::crossterm::{
-    cursor::{MoveToColumn, MoveTo},
+    cursor::{MoveTo, MoveToColumn},
     queue,
 };
 
@@ -30,7 +30,9 @@ pub fn set_scroll_region_info(h: u16, reserved: u16) {
 #[inline]
 pub fn get_scroll_region_info() -> Option<(u16, u16)> {
     let h = SCROLL_H.load(Ordering::Relaxed);
-    if h == 0 { return None; }
+    if h == 0 {
+        return None;
+    }
     let r = SCROLL_RESERVED.load(Ordering::Relaxed);
     Some((h, r))
 }
@@ -39,7 +41,9 @@ pub fn get_scroll_region_info() -> Option<(u16, u16)> {
 static PRINT_COUNT: AtomicU64 = AtomicU64::new(0);
 
 #[inline]
-pub fn printed_lines() -> usize { PRINT_COUNT.load(Ordering::Relaxed).try_into().unwrap() }
+pub fn printed_lines() -> usize {
+    PRINT_COUNT.load(Ordering::Relaxed).try_into().unwrap()
+}
 
 /// Low-level function used by [`repl_println!`] to print a formatted line.
 ///
@@ -80,8 +84,10 @@ pub fn repl_print(args: std::fmt::Arguments) -> std::io::Result<()> {
     }
     write!(out, "{}", args)?;
     write!(out, "\r\n")?;
-    out.flush()
-        .map(|_| { PRINT_COUNT.fetch_add(1, Ordering::Relaxed); () })
+    out.flush().map(|_| {
+        PRINT_COUNT.fetch_add(1, Ordering::Relaxed);
+        ()
+    })
 }
 
 /// Print a line that behaves well in raw/alternate screen contexts.

--- a/src/prompt/input.rs
+++ b/src/prompt/input.rs
@@ -1,11 +1,11 @@
-use bevy::prelude::*;
 use bevy::input::keyboard::KeyboardInput;
+use bevy::prelude::*;
 use bevy_ratatui::crossterm::event::KeyEventKind as CrosstermKeyEventKind;
-use bevy_ratatui::event::KeyEvent;
+use bevy_ratatui::event::KeyMessage;
 use std::io::{stdout, Write};
 
-use crate::repl::{Repl, ReplBufferEvent, ReplSubmitEvent, ReplSet};
 use crate::prompt::keymap::PromptKeymap;
+use crate::repl::{Repl, ReplBufferEvent, ReplSet, ReplSubmitEvent};
 
 pub struct PromptInputPlugin;
 
@@ -26,7 +26,7 @@ impl Plugin for PromptInputPlugin {
                 // prevent key events from reaching game systems while typing into the prompt.
                 block_keyboard_input_forwarding
                     .in_set(ReplSet::Post)
-                    .in_set(ReplSet::All)
+                    .in_set(ReplSet::All),
             ),
         );
     }
@@ -35,7 +35,6 @@ impl Plugin for PromptInputPlugin {
 /// System that updates the REPL buffer with events from the prompt. This is
 /// separate from the system that directly handles key events to allow for
 /// custom keybinds.
-// MIGRATION: EventReader -> MessageReader, EventWriter -> MessageWriter for buffered events
 fn update_repl_buffer(
     mut repl: ResMut<Repl>,
     mut buffer_events: MessageReader<ReplBufferEvent>,
@@ -79,7 +78,6 @@ fn update_repl_buffer(
 
 /// System that blocks keyboard input from being forwarded to Bevy when REPL is enabled to
 /// prevent key events from reaching game systems while typing into the prompt.
-// MIGRATION: Events<T> -> Messages<T> for buffered events
 pub(super) fn block_keyboard_input_forwarding(
     mut key_events: ResMut<Messages<KeyboardInput>>,
     mut keyboard_input: ResMut<ButtonInput<KeyCode>>,
@@ -98,10 +96,8 @@ pub(super) fn block_keyboard_input_forwarding(
 /// and stored to the REPL buffer. Ctrl+C is an exception because it is
 /// explicitly handled with the `ctrlc` crate in
 /// [`crate::repl::install_terminal_safety_nets`].
-// MIGRATION: EventWriter -> MessageWriter for ReplBufferEvent  
-// NOTE: KeyEvent from bevy_ratatui is likely still an Event, not a Message
 pub(super) fn parse_terminal_input(
-    mut crossterm_key_events: EventReader<KeyEvent>,  // FIXME: Check if KeyEvent needs update in bevy_ratatui 0.17
+    mut crossterm_key_events: MessageReader<KeyMessage>,
     mut buffer_events: MessageWriter<ReplBufferEvent>,
     keymap: Res<PromptKeymap>,
 ) {

--- a/src/prompt/input.rs
+++ b/src/prompt/input.rs
@@ -35,10 +35,11 @@ impl Plugin for PromptInputPlugin {
 /// System that updates the REPL buffer with events from the prompt. This is
 /// separate from the system that directly handles key events to allow for
 /// custom keybinds.
+// MIGRATION: EventReader -> MessageReader, EventWriter -> MessageWriter for buffered events
 fn update_repl_buffer(
     mut repl: ResMut<Repl>,
-    mut buffer_events: EventReader<ReplBufferEvent>,
-    mut parse_events: EventWriter<ReplSubmitEvent>,
+    mut buffer_events: MessageReader<ReplBufferEvent>,
+    mut parse_events: MessageWriter<ReplSubmitEvent>,
 ) {
     for event in buffer_events.read() {
         match event {
@@ -78,8 +79,9 @@ fn update_repl_buffer(
 
 /// System that blocks keyboard input from being forwarded to Bevy when REPL is enabled to
 /// prevent key events from reaching game systems while typing into the prompt.
+// MIGRATION: Events<T> -> Messages<T> for buffered events
 pub(super) fn block_keyboard_input_forwarding(
-    mut key_events: ResMut<Events<KeyboardInput>>,
+    mut key_events: ResMut<Messages<KeyboardInput>>,
     mut keyboard_input: ResMut<ButtonInput<KeyCode>>,
 ) {
     // Clear all keyboard events
@@ -96,9 +98,11 @@ pub(super) fn block_keyboard_input_forwarding(
 /// and stored to the REPL buffer. Ctrl+C is an exception because it is
 /// explicitly handled with the `ctrlc` crate in
 /// [`crate::repl::install_terminal_safety_nets`].
+// MIGRATION: EventWriter -> MessageWriter for ReplBufferEvent  
+// NOTE: KeyEvent from bevy_ratatui is likely still an Event, not a Message
 pub(super) fn parse_terminal_input(
-    mut crossterm_key_events: EventReader<KeyEvent>,
-    mut buffer_events: EventWriter<ReplBufferEvent>,
+    mut crossterm_key_events: EventReader<KeyEvent>,  // FIXME: Check if KeyEvent needs update in bevy_ratatui 0.17
+    mut buffer_events: MessageWriter<ReplBufferEvent>,
     keymap: Res<PromptKeymap>,
 ) {
     for event in crossterm_key_events.read() {

--- a/src/prompt/keymap.rs
+++ b/src/prompt/keymap.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_ratatui::crossterm::event::{KeyCode, KeyModifiers};
-use bevy_ratatui::event::KeyEvent;
+use bevy_ratatui::event::KeyMessage;
 
 use crate::repl::ReplBufferEvent;
 
@@ -18,7 +18,7 @@ pub struct Binding {
     pub mods: KeyModifiers,
 }
 impl Binding {
-    fn matches(&self, ev: &KeyEvent) -> bool {
+    fn matches(&self, ev: &KeyMessage) -> bool {
         // For non-character keys, SHIFT is often inconsistently reported by terminals.
         // Treat SHIFT as a no-op for non-char keys by normalizing it away for comparison.
         match self.code {
@@ -90,31 +90,55 @@ impl Default for PromptKeymap {
         use KeyCode as K;
         use KeyModifiers as M;
         Self {
-            submit:    Some(Binding { code: K::Enter,     mods: M::NONE }),
-            backspace: Some(Binding { code: K::Backspace, mods: M::NONE }),
-            left:      Some(Binding { code: K::Left,      mods: M::NONE }),
-            right:     Some(Binding { code: K::Right,     mods: M::NONE }),
-            home:      Some(Binding { code: K::Home,      mods: M::NONE }),
-            end:       Some(Binding { code: K::End,       mods: M::NONE }),
-            delete:    Some(Binding { code: K::Delete,    mods: M::NONE }),
-            clear:     Some(Binding { code: K::Esc,       mods: M::NONE }),
+            submit: Some(Binding {
+                code: K::Enter,
+                mods: M::NONE,
+            }),
+            backspace: Some(Binding {
+                code: K::Backspace,
+                mods: M::NONE,
+            }),
+            left: Some(Binding {
+                code: K::Left,
+                mods: M::NONE,
+            }),
+            right: Some(Binding {
+                code: K::Right,
+                mods: M::NONE,
+            }),
+            home: Some(Binding {
+                code: K::Home,
+                mods: M::NONE,
+            }),
+            end: Some(Binding {
+                code: K::End,
+                mods: M::NONE,
+            }),
+            delete: Some(Binding {
+                code: K::Delete,
+                mods: M::NONE,
+            }),
+            clear: Some(Binding {
+                code: K::Esc,
+                mods: M::NONE,
+            }),
             allow_plain_char_insert: true,
         }
     }
 }
 
 impl PromptKeymap {
-    pub fn map(&self, event: &KeyEvent) -> Option<ReplBufferEvent> {
+    pub fn map(&self, event: &KeyMessage) -> Option<ReplBufferEvent> {
         // Explicit bindings (exact key + modifiers), ordered by precedence
         if let Some(ev) = [
-            (self.submit.as_ref(),    ReplBufferEvent::Submit),
+            (self.submit.as_ref(), ReplBufferEvent::Submit),
             (self.backspace.as_ref(), ReplBufferEvent::Backspace),
-            (self.left.as_ref(),      ReplBufferEvent::MoveLeft),
-            (self.right.as_ref(),     ReplBufferEvent::MoveRight),
-            (self.home.as_ref(),      ReplBufferEvent::JumpToStart),
-            (self.end.as_ref(),       ReplBufferEvent::JumpToEnd),
-            (self.delete.as_ref(),    ReplBufferEvent::Delete),
-            (self.clear.as_ref(),     ReplBufferEvent::Clear),
+            (self.left.as_ref(), ReplBufferEvent::MoveLeft),
+            (self.right.as_ref(), ReplBufferEvent::MoveRight),
+            (self.home.as_ref(), ReplBufferEvent::JumpToStart),
+            (self.end.as_ref(), ReplBufferEvent::JumpToEnd),
+            (self.delete.as_ref(), ReplBufferEvent::Delete),
+            (self.clear.as_ref(), ReplBufferEvent::Clear),
         ]
         .into_iter()
         .find_map(|(b, out)| b.and_then(|b| b.matches(event).then_some(out)))
@@ -134,14 +158,14 @@ impl PromptKeymap {
 
     pub fn none() -> Self {
         Self {
-            submit:    None,
+            submit: None,
             backspace: None,
-            left:      None,
-            right:     None,
-            home:      None,
-            end:       None,
-            delete:    None,
-            clear:     None,
+            left: None,
+            right: None,
+            home: None,
+            end: None,
+            delete: None,
+            clear: None,
             allow_plain_char_insert: false,
         }
     }

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -1,14 +1,14 @@
 pub mod input;
+pub mod keymap;
 pub mod renderer;
 pub mod scroll;
-pub mod keymap;
 
 use bevy::prelude::*;
 use std::sync::Arc;
 
 use self::input::PromptInputPlugin;
 use self::keymap::PromptKeymapPlugin;
-use self::renderer::{PromptRenderer, PromptRenderPlugin};
+use self::renderer::{PromptRenderPlugin, PromptRenderer};
 use self::scroll::ScrollRegionPlugin;
 
 /// Visual configuration for the REPL prompt bar.
@@ -30,14 +30,21 @@ impl Default for PromptPlugin {
 impl Plugin for PromptPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(ReplPrompt {
-            symbol: Some(self.config.symbol.clone().unwrap_or_else(|| "> ".to_string())),
+            symbol: Some(
+                self.config
+                    .symbol
+                    .clone()
+                    .unwrap_or_else(|| "> ".to_string()),
+            ),
             buffer: String::new(),
         });
         app.insert_resource(self.config.clone());
         app.add_plugins((
             PromptInputPlugin,
             PromptKeymapPlugin,
-            PromptRenderPlugin { renderer: self.renderer.clone() },
+            PromptRenderPlugin {
+                renderer: self.renderer.clone(),
+            },
             ScrollRegionPlugin,
         ));
     }

--- a/src/prompt/renderer/helpers.rs
+++ b/src/prompt/renderer/helpers.rs
@@ -3,7 +3,12 @@ use ratatui::layout::Rect;
 /// Compute the bottom-aligned bar area with the given height inside the total frame area.
 pub fn bottom_bar_area(total: Rect, height: u16) -> Rect {
     if total.height == 0 || height == 0 || total.height < height {
-        return Rect { x: total.x, y: total.y, width: total.width, height: 0 };
+        return Rect {
+            x: total.x,
+            y: total.y,
+            width: total.width,
+            height: 0,
+        };
     }
     Rect {
         x: total.x,

--- a/src/prompt/renderer/mod.rs
+++ b/src/prompt/renderer/mod.rs
@@ -7,9 +7,9 @@ use bevy::prelude::*;
 use bevy_ratatui::RatatuiContext;
 use ratatui::layout::Rect;
 
-use crate::repl::{Repl, ReplSet};
 use super::{ReplPrompt, ReplPromptConfig};
-
+use crate::context::ReplContext;
+use crate::repl::{Repl, ReplSet};
 
 /// Public label: "scroll region ready". Always available, even in minimal mode.
 pub struct PromptRenderPlugin {
@@ -49,10 +49,13 @@ impl Plugin for PromptRenderPlugin {
     }
 }
 
-/// Render entrypoint: delegates to the active renderer strategy
+/// Render entrypoint: delegates to the active renderer strategy.
+///
+/// Prefers `RatatuiContext` (alternate screen) when present, otherwise falls
+/// back to `ReplContext` (main screen, no alternate screen).
 pub(super) fn display_prompt(
-    // Prefer ratatui's default terminal context when present (alternate screen)
     term_ratatui: Option<ResMut<RatatuiContext>>,
+    term_repl: Option<ResMut<ReplContext>>,
     repl: Res<Repl>,
     prompt: Res<ReplPrompt>,
     visuals: Option<Res<ReplPromptConfig>>,
@@ -60,11 +63,25 @@ pub(super) fn display_prompt(
 ) {
     let visuals = visuals.map(|v| v.clone()).unwrap_or_default();
 
+    let render = |f: &mut ratatui::Frame<'_>| {
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: f.area().width,
+            height: f.area().height,
+        };
+        let ctx = RenderCtx {
+            repl: &repl,
+            prompt: &prompt,
+            visuals: &visuals,
+            area,
+        };
+        active.0.render(f, &ctx);
+    };
+
     if let Some(mut term) = term_ratatui {
-        let _ = term.draw(|f| {
-            let area = Rect { x: 0, y: 0, width: f.area().width, height: f.area().height };
-            let ctx = RenderCtx { repl: &repl, prompt: &prompt, visuals: &visuals, area };
-            active.0.render(f, &ctx);
-        });
-    } else { return }; // No terminal context yet
+        let _ = term.draw(render);
+    } else if let Some(mut term) = term_repl {
+        let _ = term.draw(render);
+    }
 }

--- a/src/prompt/renderer/simple.rs
+++ b/src/prompt/renderer/simple.rs
@@ -1,23 +1,26 @@
-
+use super::helpers::{bottom_bar_area, buffer_window, cursor_position};
+use super::{PromptRenderer, RenderCtx};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 use ratatui::Frame;
-use super::{RenderCtx, PromptRenderer};
-use super::helpers::{bottom_bar_area, buffer_window, cursor_position};
 
 /// Simple renderer: single line, no borders, no colors, no hints
 pub struct SimpleRenderer;
 impl PromptRenderer for SimpleRenderer {
     fn render(&self, f: &mut Frame<'_>, ctx: &RenderCtx) {
         // Always one line
-        if ctx.area.height == 0 { return; }
+        if ctx.area.height == 0 {
+            return;
+        }
         let area = bottom_bar_area(ctx.area, 1);
 
         // Layout
         let left_area = area;
         let prompt_symbol = ctx.prompt.symbol.clone().unwrap_or_default();
         let prompt_width = prompt_symbol.len() as u16;
-        if left_area.width <= prompt_width { return; }
+        if left_area.width <= prompt_width {
+            return;
+        }
         let visible_width = left_area.width - prompt_width;
 
         // Buffer windowing
@@ -27,7 +30,9 @@ impl PromptRenderer for SimpleRenderer {
 
         // Render text
         let mut spans = Vec::with_capacity(2);
-        if !prompt_symbol.is_empty() { spans.push(Span::raw(prompt_symbol)); }
+        if !prompt_symbol.is_empty() {
+            spans.push(Span::raw(prompt_symbol));
+        }
         spans.push(Span::raw(visible_buf));
         f.render_widget(Paragraph::new(Line::from(spans)), left_area);
 

--- a/src/prompt/scroll.rs
+++ b/src/prompt/scroll.rs
@@ -1,8 +1,8 @@
 use bevy::prelude::*;
-use std::io::{stdout, Write};
 use bevy_ratatui::crossterm::terminal;
+use std::io::{stdout, Write};
 
-use crate::print::{set_scroll_region_info, printed_lines};
+use crate::print::{printed_lines, set_scroll_region_info};
 use crate::repl::{Repl, ReplSet};
 
 pub struct ScrollRegionPlugin;
@@ -15,12 +15,10 @@ impl Plugin for ScrollRegionPlugin {
         // terminal size isn't ready at Startup and to provide ordering guarantees.
         app.add_systems(
             PostStartup,
-            (
-                manage_scroll_region
-                    .in_set(ReplSet::All)
-                    .after(ReplSet::Render)
-                    .before(ReplSet::Post),
-            ),
+            (manage_scroll_region
+                .in_set(ReplSet::All)
+                .after(ReplSet::Render)
+                .before(ReplSet::Post),),
         );
     }
 }
@@ -34,16 +32,19 @@ pub struct ScrollRegionState {
 
 /// Ensure the terminal scroll region reserves the bottom prompt area so that
 /// stdout/logs scroll above the REPL prompt instead of overwriting it.
-fn manage_scroll_region(
-    repl: Res<Repl>,
-    mut last: Local<Option<ScrollRegionState>>,
-) {
+fn manage_scroll_region(repl: Res<Repl>, mut last: Local<Option<ScrollRegionState>>) {
     let reserved_lines: u16 = if repl.enabled { 1 } else { 0 };
 
     // Read terminal size; if unavailable, do nothing
-    let Ok((_w, h)) = terminal::size() else { return };
+    let Ok((_w, h)) = terminal::size() else {
+        return;
+    };
 
-    let desired = ScrollRegionState { enabled: repl.enabled, height: h, reserved_lines };
+    let desired = ScrollRegionState {
+        enabled: repl.enabled,
+        height: h,
+        reserved_lines,
+    };
     if last.as_ref() == Some(&desired) {
         return; // No change
     }
@@ -64,7 +65,13 @@ fn manage_scroll_region(
         let bottom = h.saturating_sub(reserved_lines);
         let _ = write!(out, "\x1B[1;{}r", bottom);
         set_scroll_region_info(h, reserved_lines);
-        scroll_reserved_region_up(&mut out, bottom, reserved_lines, prev_reserved, printed_lines());
+        scroll_reserved_region_up(
+            &mut out,
+            bottom,
+            reserved_lines,
+            prev_reserved,
+            printed_lines(),
+        );
     }
     let _ = out.flush();
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -35,17 +35,23 @@ impl Default for ReplPlugin {
 impl ReplPlugin {
     /// Create a REPL plugin that starts enabled (default).
     pub fn enabled() -> Self {
-        Self { enable_on_startup: true }
+        Self {
+            enable_on_startup: true,
+        }
     }
 
     /// Create a REPL plugin that starts disabled (no runtime toggle in v1).
     pub fn disabled() -> Self {
-        Self { enable_on_startup: false }
+        Self {
+            enable_on_startup: false,
+        }
     }
 
     /// Configure whether the REPL starts enabled.
     pub fn with_enabled(enabled: bool) -> Self {
-        Self { enable_on_startup: enabled }
+        Self {
+            enable_on_startup: enabled,
+        }
     }
 }
 
@@ -55,13 +61,11 @@ impl Plugin for ReplPlugin {
             enabled: self.enable_on_startup,
             ..default()
         });
-        // MIGRATION: These are buffered events, now Messages in 0.17
         app.add_message::<ReplSubmitEvent>();
         app.add_message::<ReplBufferEvent>();
-        // Internal lifecycle event to manage terminal context without runtime toggle
         app.add_message::<ReplLifecycleEvent>();
         app.add_systems(Startup, emit_enable_if_enabled);
-        app.add_observer(on_app_exit_emit_disable);
+        app.add_systems(Last, on_app_exit_emit_disable);
         app.configure_sets(
             Update,
             (
@@ -71,15 +75,13 @@ impl Plugin for ReplPlugin {
                 ReplSet::Render,
                 ReplSet::Post,
             )
-                .chain()
+                .chain(),
         );
         // Wrapper set to anchor all REPL systems at the end of the ratatui set.
         // All of the REPL sets only run when the REPL is enabled.
         app.configure_sets(
             Update,
-            ReplSet::All
-                .in_set(InputSet::Post)
-                .run_if(repl_is_enabled),
+            ReplSet::All.in_set(InputSet::Post).run_if(repl_is_enabled),
         );
     }
 }
@@ -166,28 +168,27 @@ pub enum ReplSet {
     Post,
 }
 
-// MIGRATION: Changed from Event to Message - this is a buffered event
 #[derive(Message, Clone)]
 pub enum ReplLifecycleEvent {
     Enable,
     Disable,
 }
 
-// TODO: someday this could be a system triggered by state transitions
-// MIGRATION: EventWriter -> MessageWriter for buffered events
 fn emit_enable_if_enabled(repl: Res<Repl>, mut writer: MessageWriter<ReplLifecycleEvent>) {
     if repl.enabled {
         writer.write(ReplLifecycleEvent::Enable);
     }
 }
 
-// MIGRATION: Trigger<T> -> On<T> for observer params
-// MIGRATION: EventWriter -> MessageWriter for buffered events  
-fn on_app_exit_emit_disable(_exit: On<AppExit>, mut writer: MessageWriter<ReplLifecycleEvent>) {
-    writer.write(ReplLifecycleEvent::Disable);
+fn on_app_exit_emit_disable(
+    mut exit: MessageReader<AppExit>,
+    mut writer: MessageWriter<ReplLifecycleEvent>,
+) {
+    for _ in exit.read() {
+        writer.write(ReplLifecycleEvent::Disable);
+    }
 }
 
-// MIGRATION: Changed from Event to Message - this is a buffered event
 #[derive(Message, Debug, Clone)]
 pub enum ReplBufferEvent {
     Insert(char),
@@ -201,6 +202,5 @@ pub enum ReplBufferEvent {
     Submit,
 }
 
-// MIGRATION: Changed from Event to Message - this is a buffered event
 #[derive(Message, Debug, Clone)]
 pub struct ReplSubmitEvent(pub String);

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -55,10 +55,11 @@ impl Plugin for ReplPlugin {
             enabled: self.enable_on_startup,
             ..default()
         });
-        app.add_event::<ReplSubmitEvent>();
-        app.add_event::<ReplBufferEvent>();
+        // MIGRATION: These are buffered events, now Messages in 0.17
+        app.add_message::<ReplSubmitEvent>();
+        app.add_message::<ReplBufferEvent>();
         // Internal lifecycle event to manage terminal context without runtime toggle
-        app.add_event::<ReplLifecycleEvent>();
+        app.add_message::<ReplLifecycleEvent>();
         app.add_systems(Startup, emit_enable_if_enabled);
         app.add_observer(on_app_exit_emit_disable);
         app.configure_sets(
@@ -165,24 +166,29 @@ pub enum ReplSet {
     Post,
 }
 
-#[derive(Event)]
+// MIGRATION: Changed from Event to Message - this is a buffered event
+#[derive(Message, Clone)]
 pub enum ReplLifecycleEvent {
     Enable,
     Disable,
 }
 
 // TODO: someday this could be a system triggered by state transitions
-fn emit_enable_if_enabled(repl: Res<Repl>, mut writer: EventWriter<ReplLifecycleEvent>) {
+// MIGRATION: EventWriter -> MessageWriter for buffered events
+fn emit_enable_if_enabled(repl: Res<Repl>, mut writer: MessageWriter<ReplLifecycleEvent>) {
     if repl.enabled {
         writer.write(ReplLifecycleEvent::Enable);
     }
 }
 
-fn on_app_exit_emit_disable(_exit: Trigger<AppExit>, mut writer: EventWriter<ReplLifecycleEvent>) {
+// MIGRATION: Trigger<T> -> On<T> for observer params
+// MIGRATION: EventWriter -> MessageWriter for buffered events  
+fn on_app_exit_emit_disable(_exit: On<AppExit>, mut writer: MessageWriter<ReplLifecycleEvent>) {
     writer.write(ReplLifecycleEvent::Disable);
 }
 
-#[derive(Event, Debug)]
+// MIGRATION: Changed from Event to Message - this is a buffered event
+#[derive(Message, Debug, Clone)]
 pub enum ReplBufferEvent {
     Insert(char),
     Backspace,
@@ -195,5 +201,6 @@ pub enum ReplBufferEvent {
     Submit,
 }
 
-#[derive(Event, Debug)]
+// MIGRATION: Changed from Event to Message - this is a buffered event
+#[derive(Message, Debug, Clone)]
 pub struct ReplSubmitEvent(pub String);


### PR DESCRIPTION
## Summary
- Bumps `bevy` from 0.18 to 0.19.
- Points `bevy_ratatui` at a git rev of [apekros/bevy_ratatui#98](https://github.com/ratatui/bevy_ratatui/pull/98) (open upstream PR bumping to Bevy 0.19) since no crates.io release supports Bevy 0.19 yet. The actual code diff needed for 0.19 support is trivial (a handful of clippy fixups), so this is a low-risk stopgap — switch back to a crates.io release once one ships.
- Fixes a deprecation: `App::insert_non_send_resource` → `App::insert_non_send`.
- Minor patch bumps to `ratatui`, `clap`, and `anyhow` that were already pending in the working tree.

## Test plan
- [x] `cargo check` passes
- [x] `cargo build --examples` passes (default features)
- [x] `cargo test --lib` passes (13/13)
- [ ] Revisit the `bevy_ratatui` git dependency once a crates.io release supports Bevy 0.19 --> #15 